### PR TITLE
Update Face API to v1.

### DIFF
--- a/dist/face.js
+++ b/dist/face.js
@@ -1,16 +1,19 @@
 'use strict';
 
-var request = require('request'),
+var request = require('request').defaults({
+    baseUrl: 'https://api.projectoxford.ai/face/v1.0/',
+    headers: { 'User-Agent': 'nodejs/0.3.0' } }),
     fs = require('fs'),
     _Promise = require('bluebird');
 
-var detectUrl = 'https://api.projectoxford.ai/face/v0/detections';
-var similarUrl = 'https://api.projectoxford.ai/face/v0/findsimilars';
-var groupingUrl = 'https://api.projectoxford.ai/face/v0/groupings';
-var identifyUrl = 'https://api.projectoxford.ai/face/v0/identifications';
-var verifyUrl = 'https://api.projectoxford.ai/face/v0/verifications';
-var personGroupUrl = 'https://api.projectoxford.ai/face/v0/persongroups';
-var personUrl = 'https://api.projectoxford.ai/face/v0/persongroups';
+var detectUrl = '/detect';
+var similarUrl = '/findsimilars';
+var groupingUrl = '/group';
+var identifyUrl = '/identify';
+var verifyUrl = '/verify';
+var personGroupUrl = '/persongroups';
+var personUrl = '/persongroups';
+var faceListUrl = '/facelists';
 
 /**
  * @namespace
@@ -25,25 +28,49 @@ var face = function face(key) {
             return reject(error);
         }
 
-        if (response.statusCode != 200) {
-            reject(response.body);
+        if (response.statusCode !== 200 && response.statusCode !== 202) {
+            reject(response.body.error || response.body);
         }
 
         return resolve(response.body);
-    };
+    }
 
     /**
-     * (Private) Call the Face Detected API using a stream of an image
+     * (Private) Post an online image to a face API URL
      *
      * @private
+     * @param  {string} url         - Url to POST
+     * @param  {string} image       - Url to the image
+     * @param  {object} options     - Querystring object
+     * @return {Promise}            - Promise resolving with the resulting JSON
+     */
+    function _postOnline(url, image, options) {
+        return new _Promise(function (resolve, reject) {
+            request.post({
+                uri: url,
+                headers: { 'Ocp-Apim-Subscription-Key': key },
+                json: true,
+                body: { url: image },
+                qs: options
+            }, function (error, response) {
+                return _return(error, response, resolve, reject);
+            });
+        });
+    }
+
+    /**
+     * (Private) Post an image stream to a face API URL
+     *
+     * @private
+     * @param  {string} url         - Url to POST
      * @param  {stream} stream      - Stream for the image
      * @param  {object} options     - Querystring object
      * @return {Promise}            - Promise resolving with the resulting JSON
      */
-    function _detectStream(stream, options) {
+    function _postStream(url, stream, options) {
         return new _Promise(function (resolve, reject) {
             stream.pipe(request.post({
-                uri: detectUrl,
+                uri: url,
                 headers: {
                     'Ocp-Apim-Subscription-Key': key,
                     'Content-Type': 'application/octet-stream'
@@ -54,41 +81,44 @@ var face = function face(key) {
                 _return(error, response, resolve, reject);
             }));
         });
-    };
+    }
 
     /**
-     * (Private) Call the Face Detected API using a local image
+     * (Private) Post a local image file to a face API URL
      *
      * @private
+     * @param  {string} url         - Url to POST
      * @param  {string} image       - Path to the image
      * @param  {object} options     - Querystring object
      * @return {Promise}            - Promise resolving with the resulting JSON
      */
-    function _detectLocal(image, options) {
-        return _detectStream(fs.createReadStream(image), options);
-    };
+    function _postLocal(url, image, options) {
+        return _postStream(url, fs.createReadStream(image), options);
+    }
 
     /**
-     * (Private) Call the Face Detected API using a uri to an online image
+     * (Private)  Post an image to a face API URL.
      *
      * @private
-     * @param  {string} image       - Url to the image
-     * @param  {object} options     - Querystring object
-     * @return {Promise}            - Promise resolving with the resulting JSON
+     * @param  {string} url           - URL to post
+     * @param  {object} source        - Union of sources
+     * @param  {string} source.url    - URL of image
+     * @param  {string} source.path   - Local path of image
+     * @param  {string} source.stream - Stream of image
+     * @param  {object} qs            - Querystring object
+     * @return {Promise}              - Promise resolving with the resulting JSON
      */
-    function _detectOnline(image, options) {
-        return new _Promise(function (resolve, reject) {
-            request.post({
-                uri: detectUrl,
-                headers: { 'Ocp-Apim-Subscription-Key': key },
-                json: true,
-                body: { url: image },
-                qs: options
-            }, function (error, response) {
-                return _return(error, response, resolve, reject);
-            });
-        });
-    };
+    function _postImage(url, source, qs) {
+        if (source.url && source.url !== '') {
+            return _postOnline(url, source.url, qs);
+        }
+        if (source.path && source.path !== '') {
+            return _postLocal(url, source.path, qs);
+        }
+        if (source.stream) {
+            return _postStream(url, source.stream, qs);
+        }
+    }
 
     /**
      * Call the Face Detected API
@@ -101,46 +131,66 @@ var face = function face(key) {
      * @param  {string}  options.url                    - URL to image to be used
      * @param  {string}  options.path                   - Path to image to be used
      * @param  {stream}  options.stream                 - Stream for image to be used
+     * @param  {boolean} options.returnFaceId           - Include face ID in response?
      * @param  {boolean} options.analyzesFaceLandmarks  - Analyze face landmarks?
      * @param  {boolean} options.analyzesAge            - Analyze age?
      * @param  {boolean} options.analyzesGender         - Analyze gender?
      * @param  {boolean} options.analyzesHeadPose       - Analyze headpose?
+     * @param  {boolean} options.analyzesSmile          - Analyze smile?
+     * @param  {boolean} options.analyzesFacialHair     - Analyze facial hair?
      * @return {Promise}                                - Promise resolving with the resulting JSON
      */
     function detect(options) {
+        var attributes = [];
+        if (options.analyzesAge) {
+            attributes.push('age');
+        }
+        if (options.analyzesGender) {
+            attributes.push('gender');
+        }
+        if (options.analyzesHeadPose) {
+            attributes.push('headPose');
+        }
+        if (options.analyzesSmile) {
+            attributes.push('smile');
+        }
+        if (options.analyzesFacialHair) {
+            attributes.push('facialHair');
+        }
         var qs = {
-            analyzesFaceLandmarks: options.analyzesFaceLandmarks ? true : false,
-            analyzesAge: options.analyzesAge ? true : false,
-            analyzesGender: options.analyzesGender ? true : false,
-            analyzesHeadPose: options.analyzesHeadPose ? true : false
+            returnFaceId: !!options.returnFaceId,
+            returnFaceLandmarks: !!options.analyzesFaceLandmarks,
+            returnFaceAttributes: attributes.join()
         };
 
-        if (options.url && options.url !== '') {
-            return _detectOnline(options.url, qs);
-        }
-
-        if (options.path && options.path !== '') {
-            return _detectLocal(options.path, qs);
-        }
-
-        if (options.stream) {
-            return _detectStream(options.stream, qs);
-        }
-    };
+        return _postImage(detectUrl, options, qs);
+    }
 
     /**
-     * Detect similar faces using faceIds (as returned from the detect API)
-     * @param  {string} sourceFace          - String of faceId for the source face
-     * @param  {string[]} candidateFaces    - Array of faceIds to use as candidates
-     * @return {Promise}                    - Promise resolving with the resulting JSON
+     * Detect similar faces using faceIds (as returned from the detect API), or faceListId
+     * (as returned from the facelist API).
+     * @param  {string}   sourceFace                  - String of faceId for the source face
+     * @param  {object}   options                     - Options object
+     * @param  {string[]} options.candidateFaces      - Array of faceIds to use as candidates
+     * @param  {string}   options.candidateFaceListId - Id of face list, created via FaceList.create
+     * @param  {Number}   options.maxCandidates       - Optional max number for top candidates (default is 20, max is 20)
+     * @return {Promise}                              - Promise resolving with the resulting JSON
      */
-    function similar(sourceFace, candidateFaces) {
+    function similar(sourceFace, options) {
         return new _Promise(function (resolve, reject) {
             var faces = {
-                faceId: sourceFace,
-                faceIds: candidateFaces
+                faceId: sourceFace
             };
-
+            if (options) {
+                if (options.candidateFaceListId) {
+                    faces.faceListId = options.candidateFaceListId;
+                } else {
+                    faces.faceIds = options.candidateFaces;
+                }
+                if (options.maxCandidates) {
+                    faces.maxNumOfCandidatesReturned = options.maxCandidates;
+                }
+            }
             request.post({
                 uri: similarUrl,
                 headers: { 'Ocp-Apim-Subscription-Key': key },
@@ -150,7 +200,7 @@ var face = function face(key) {
                 return _return(error, response, resolve, reject);
             });
         });
-    };
+    }
 
     /**
      * Divides candidate faces into groups based on face similarity using faceIds.
@@ -181,7 +231,7 @@ var face = function face(key) {
                 return _return(error, response, resolve, reject);
             });
         });
-    };
+    }
 
     /**
      * Identifies persons from a person group by one or more input faces.
@@ -191,22 +241,18 @@ var face = function face(key) {
      * identification API compares the input face to those persons' faces in person group and
      * returns the best-matched candidate persons, ranked by confidence.
      *
-     * @param  {string[]} faces     - Array of faceIds to use
-     * @return {Promise}            - Promise resolving with the resulting JSON
+     * @param  {string[]} faces                     - Array of faceIds to use
+     * @param  {string} personGroupId               - Id of person group from which faces will be identified
+     * @param  {Number} maxNumOfCandidatesReturned  - Optional max number of candidates per face (default=1, max=5)
+     * @return {Promise}                            - Promise resolving with the resulting JSON
      */
-    function identify(faces, options) {
+    function identify(faces, personGroupId, maxNumOfCandidatesReturned) {
         return new _Promise(function (resolve, reject) {
-            var body = {};
-
-            if (options && options.personGroupId) {
-                body.personGroupId = options.personGroupId;
-            }
-
-            if (options && options.maxNumOfCandidatesReturned) {
-                body.maxNumOfCandidatesReturned = options.maxNumOfCandidatesReturned;
-            }
-
-            body.faceIds = faces;
+            var body = {
+                faceIds: faces,
+                personGroupId: personGroupId,
+                maxNumOfCandidatesReturned: maxNumOfCandidatesReturned || 1
+            };
 
             request.post({
                 uri: identifyUrl,
@@ -217,7 +263,7 @@ var face = function face(key) {
                 return _return(error, response, resolve, reject);
             });
         });
-    };
+    }
 
     /**
      * Analyzes two faces and determine whether they are from the same person.
@@ -246,6 +292,163 @@ var face = function face(key) {
                 return reject('Faces array must contain two face ids');
             }
         });
+    }
+
+    /**
+     * @namespace
+     * @memberof face
+     */
+    var faceList = {
+        /**
+         * Lists the faceListIds, and associated names and/or userData.
+         * @return {Promise} - Promise resolving with the resulting JSON
+         */
+        list: function list() {
+            return new _Promise(function (resolve, reject) {
+                request({
+                    uri: faceListUrl,
+                    headers: { 'Ocp-Apim-Subscription-Key': key }
+                }, function (error, response) {
+                    response.body = JSON.parse(response.body);
+                    return _return(error, response, resolve, reject);
+                });
+            });
+        },
+
+        /**
+         * Creates a new face list with a user-specified ID.
+         * A face list is a list of faces associated to be associated with a given person.
+         *
+         * @param  {string} faceListId          - Numbers, en-us letters in lower case, '-', '_'. Max length: 64
+         * @param  {object} options             - Optional parameters
+         * @param  {string} options.name        - Name of the face List
+         * @param  {string} options.userData    - User-provided data associated with the face list.
+         * @return {Promise}                    - Promise resolving with the resulting JSON
+         */
+        create: function create(faceListId, options) {
+            var body = {};
+            if (options) {
+                body.name = options.name;
+                body.userData = options.userData;
+            }
+            return new _Promise(function (resolve, reject) {
+                request.put({
+                    uri: faceListUrl + '/' + faceListId,
+                    headers: { 'Ocp-Apim-Subscription-Key': key },
+                    json: true,
+                    body: body
+                }, function (error, response) {
+                    return _return(error, response, resolve, reject);
+                });
+            });
+        },
+
+        /**
+         * Creates a new person group with a user-specified ID.
+         * A person group is one of the most important parameters for the Identification API.
+         * The Identification searches person faces in a specified person group.
+         *
+         * @param  {string} faceListId          - Numbers, en-us letters in lower case, '-', '_'. Max length: 64
+         * @param  {object} options             - Optional parameters
+         * @param  {string} options.name        - Name of the face List
+         * @param  {string} options.userData    - User-provided data associated with the face list.
+         * @return {Promise}                    - Promise resolving with the resulting JSON
+         */
+        update: function update(faceListId, options) {
+            var body = {};
+            if (options) {
+                body.name = options.name;
+                body.userData = options.userData;
+            }
+            return new _Promise(function (resolve, reject) {
+                request.patch({
+                    uri: faceListUrl + '/' + faceListId,
+                    headers: { 'Ocp-Apim-Subscription-Key': key },
+                    json: true,
+                    body: body
+                }, function (error, response) {
+                    return _return(error, response, resolve, reject);
+                });
+            });
+        },
+
+        /**
+         * Deletes an existing person group.
+         *
+         * @param  {string} faceListId          - ID of face list to delete
+         * @return {Promise}                    - Promise resolving with the resulting JSON
+         */
+        'delete': function _delete(faceListId) {
+            return new _Promise(function (resolve, reject) {
+                request({
+                    method: 'DELETE',
+                    uri: faceListUrl + '/' + faceListId,
+                    headers: { 'Ocp-Apim-Subscription-Key': key }
+                }, function (error, response) {
+                    return _return(error, response, resolve, reject);
+                });
+            });
+        },
+
+        /**
+         * Gets an existing face list.
+         *
+         * @param  {string} faceListId          - ID of face list to retrieve
+         * @return {Promise}                    - Promise resolving with the resulting JSON
+         */
+        get: function get(faceListId) {
+            return new _Promise(function (resolve, reject) {
+                request({
+                    uri: faceListUrl + '/' + faceListId,
+                    headers: { 'Ocp-Apim-Subscription-Key': key }
+                }, function (error, response) {
+                    response.body = JSON.parse(response.body);
+                    return _return(error, response, resolve, reject);
+                });
+            });
+        },
+
+        /**
+         * Gets an existing face list.
+         *
+         * @param  {string} faceListId          - ID of face list to retrieve
+         * @param  {object} options             - Options object
+         * @param  {string} options.url         - URL to image to be used
+         * @param  {string} options.path        - Path to image to be used
+         * @param  {stream} options.stream      - Stream for image to be used
+         * @param  {string} options.name        - Optional name for the face
+         * @param  {string} options.userData    - Optional user-data for the face
+         * @return {Promise}                    - Promise resolving with the resulting JSON
+         */
+        addFace: function addFace(faceListId, options) {
+            var url = faceListUrl + '/' + faceListId + '/persistedFaces';
+            var qs = {};
+            if (options) {
+                qs.name = options.name;
+                qs.userData = options.userData;
+            }
+            return _postImage(url, options, qs);
+        },
+
+        /**
+         * Delete a face from the face list.  The face ID will be an ID returned in the addFace method,
+         * not from the detect method.
+         *
+         * @param  {string} faceListId          - ID of face list to retrieve
+         * @param  {string} persistedFaceId     - ID of face in the face list
+         * @return {Promise}                    - Promise; successful response is empty
+         */
+        deleteFace: function deleteFace(faceListId, persistedFaceId) {
+            return new _Promise(function (resolve, reject) {
+                request({
+                    method: 'DELETE',
+                    uri: faceListUrl + '/' + faceListId + '/persistedFaces/' + persistedFaceId,
+                    headers: { 'Ocp-Apim-Subscription-Key': key }
+                }, function (error, response) {
+                    return _return(error, response, resolve, reject);
+                });
+            });
+        }
     };
 
     /**
@@ -337,7 +540,7 @@ var face = function face(key) {
 
         /**
          * Starts a person group training.
-             * Training is a necessary preparation process of a person group before identification.
+         * Training is a necessary preparation process of a person group before identification.
          * Each person group needs to be trained in order to call Identification. The training
          * will process for a while on the server side even after this API has responded.
          *
@@ -347,10 +550,9 @@ var face = function face(key) {
         trainingStart: function trainingStart(personGroupId) {
             return new _Promise(function (resolve, reject) {
                 request.post({
-                    uri: personGroupUrl + '/' + personGroupId + '/training',
+                    uri: personGroupUrl + '/' + personGroupId + '/train',
                     headers: { 'Ocp-Apim-Subscription-Key': key }
                 }, function (error, response) {
-                    response.body = JSON.parse(response.body);
                     return _return(error, response, resolve, reject);
                 });
             });
@@ -403,27 +605,28 @@ var face = function face(key) {
      */
     var person = {
         /**
-         * Adds a face to a person for identification. The maximum face count for each person is 32.
-         * The face ID must be added to a person before its expiration. Typically a face ID expires
-         * 24 hours after detection.
+         * Adds a face to a person for identification. The maximum face count for each person is 248.
          *
-         * @param {string} personGroupId     - The target person's person group.
-         * @param {string} personId          - The target person that the face is added to.
-         * @param {string} faceId            - The ID of the face to be added. The maximum face amount for each person is 32.
-         * @param {string} userData          - Optional. Attach user data to person's face. The maximum length is 1024.
-         * @return {Promise}                 - Promise resolving with the resulting JSON
+         * @param {string} personGroupId       - The target person's person group.
+         * @param {string} personId            - The target person that the face is added to.
+         * @param {object} options             - The source specification.
+         * @param {string} options.url         - URL to image to be used.
+         * @param {string} options.path        - Path to image to be used.
+         * @param {stream} options.stream      - Stream for image to be used.
+         * @param {string} options.userData    - Optional. Attach user data to person's face. The maximum length is 1024.
+         * @param {object} options.targetFace  - Optional. The rectangle of the face in the image.
+         * @return {Promise}                   - Promise resolving with the resulting JSON
          */
-        addFace: function addFace(personGroupId, personId, faceId, userData) {
-            return new _Promise(function (resolve, reject) {
-                request.put({
-                    uri: personUrl + '/' + personGroupId + '/persons/' + personId + '/faces/' + faceId,
-                    headers: { 'Ocp-Apim-Subscription-Key': key },
-                    json: true,
-                    body: userData ? { userData: userData } : {}
-                }, function (error, response) {
-                    return _return(error, response, resolve, reject);
-                });
-            });
+        addFace: function addFace(personGroupId, personId, options) {
+            var qs = {};
+            if (options) {
+                qs.userData = options.userData;
+                if (options.targetFace) {
+                    qs.targetFace = [options.targetFace.left, options.targetFace.top, options.targetFace.width, options.targetFace.height].join();
+                }
+            }
+            var url = personUrl + '/' + personGroupId + '/persons/' + personId + '/persistedFaces';
+            return _postImage(url, options, qs);
         },
 
         /**
@@ -431,14 +634,14 @@ var face = function face(key) {
          *
          * @param {string} personGroupId     - The target person's person group.
          * @param {string} personId          - The target person that the face is removed from.
-         * @param {string} faceId            - The ID of the face to be deleted.
+         * @param {string} persistedFaceId   - The ID of the face to be deleted.
          * @return {Promise}                 - Promise resolving with the resulting JSON
          */
-        deleteFace: function deleteFace(personGroupId, personId, faceId) {
+        deleteFace: function deleteFace(personGroupId, personId, persistedFaceId) {
             return new _Promise(function (resolve, reject) {
                 request({
                     method: 'DELETE',
-                    uri: personUrl + '/' + personGroupId + '/persons/' + personId + '/faces/' + faceId,
+                    uri: personUrl + '/' + personGroupId + '/persons/' + personId + '/persistedFaces/' + persistedFaceId,
                     headers: { 'Ocp-Apim-Subscription-Key': key }
                 }, function (error, response) {
                     return _return(error, response, resolve, reject);
@@ -451,14 +654,14 @@ var face = function face(key) {
          *
          * @param {string} personGroupId     - The target person's person group.
          * @param {string} personId          - The target person that the face is updated on.
-         * @param {string} faceId            - The ID of the face to be updated.
+         * @param {string} persistedFaceId   - The ID of the face to be updated.
          * @param {string} userData          - Optional. Attach user data to person's face. The maximum length is 1024.
          * @return {Promise}                 - Promise resolving with the resulting JSON
          */
-        updateFace: function updateFace(personGroupId, personId, faceId, userData) {
+        updateFace: function updateFace(personGroupId, personId, persistedFaceId, userData) {
             return new _Promise(function (resolve, reject) {
                 request.patch({
-                    uri: personUrl + '/' + personGroupId + '/persons/' + personId + '/faces/' + faceId,
+                    uri: personUrl + '/' + personGroupId + '/persons/' + personId + '/persistedFaces/' + persistedFaceId,
                     headers: { 'Ocp-Apim-Subscription-Key': key },
                     json: true,
                     body: userData ? { userData: userData } : {}
@@ -473,13 +676,13 @@ var face = function face(key) {
          *
          * @param {string} personGroupId     - The target person's person group.
          * @param {string} personId          - The target person that the face is to get from.
-         * @param {string} faceId            - The ID of the face to get.
+         * @param {string} persistedFaceId   - The ID of the face to get.
          * @return {Promise}                 - Promise resolving with the resulting JSON
          */
-        getFace: function getFace(personGroupId, personId, faceId) {
+        getFace: function getFace(personGroupId, personId, persistedFaceId) {
             return new _Promise(function (resolve, reject) {
                 request({
-                    uri: personUrl + '/' + personGroupId + '/persons/' + personId + '/faces/' + faceId,
+                    uri: personUrl + '/' + personGroupId + '/persons/' + personId + '/persistedFaces/' + persistedFaceId,
                     headers: { 'Ocp-Apim-Subscription-Key': key }
                 }, function (error, response) {
                     response.body = JSON.parse(response.body);
@@ -491,22 +694,19 @@ var face = function face(key) {
         /**
          * Creates a new person in a specified person group for identification.
          * The number of persons has a subscription limit. Free subscription amount is 1000 persons.
-         * The maximum face count for each person is 32.
          *
          * @param {string} personGroupId     - The target person's person group.
-         * @param {string[]} faces           - Array of face id's for the target person
          * @param {string} name              - Target person's display name. The maximum length is 128.
          * @param {string} userData          - Optional fields for user-provided data attached to a person. Size limit is 16KB.
          * @return {Promise}                 - Promise resolving with the resulting JSON
          */
-        create: function create(personGroupId, faces, name, userData) {
+        create: function create(personGroupId, name, userData) {
             return new _Promise(function (resolve, reject) {
                 request.post({
                     uri: personUrl + '/' + personGroupId + '/persons',
                     headers: { 'Ocp-Apim-Subscription-Key': key },
                     json: true,
                     body: {
-                        faceIds: faces,
                         name: name,
                         userData: userData
                     }
@@ -558,19 +758,17 @@ var face = function face(key) {
          * Updates a person's information.
          *
          * @param {string} personGroupId     - The target person's person group.
-         * @param {string[]} faces           - Array of face id's for the target person
          * @param {string} name              - Target person's display name. The maximum length is 128.
          * @param {string} userData          - Optional fields for user-provided data attached to a person. Size limit is 16KB.
          * @return {Promise}                 - Promise resolving with the resulting JSON
          */
-        update: function update(personGroupId, personId, faces, name, userData) {
+        update: function update(personGroupId, personId, name, userData) {
             return new _Promise(function (resolve, reject) {
                 request.patch({
                     uri: personUrl + '/' + personGroupId + '/persons/' + personId,
                     headers: { 'Ocp-Apim-Subscription-Key': key },
                     json: true,
                     body: {
-                        faceIds: faces,
                         name: name,
                         userData: userData
                     }
@@ -605,6 +803,7 @@ var face = function face(key) {
         grouping: grouping,
         identify: identify,
         verify: verify,
+        faceList: faceList,
         personGroup: personGroup,
         person: person
     };

--- a/dist/vision.js
+++ b/dist/vision.js
@@ -1,14 +1,16 @@
 'use strict';
 
-var request = require('request'),
+var request = require('request').defaults({
+    baseUrl: 'https://api.projectoxford.ai/vision/v1/',
+    headers: { 'User-Agent': 'nodejs/0.3.0' } }),
     fs = require('fs'),
     _Promise = require('bluebird');
 
-var analyzeUrl = 'https://api.projectoxford.ai/vision/v1/analyses';
-var thumbnailUrl = 'https://api.projectoxford.ai/vision/v1/thumbnails';
-var ocrUrl = 'https://api.projectoxford.ai/vision/v1/ocr';
+var analyzeUrl = '/analyses';
+var thumbnailUrl = '/thumbnails';
+var ocrUrl = '/ocr';
 
-/** 
+/**
  * @namespace
  * @memberof Client
  */
@@ -21,12 +23,12 @@ var vision = function vision(key) {
             return reject(error);
         }
 
-        if (response.statusCode != 200) {
+        if (response.statusCode !== 200) {
             reject(response.body);
         }
 
         return resolve(response.body);
-    };
+    }
 
     /**
      * (Private) Analyze a local image, using a fs pipe

--- a/src/emotion.js
+++ b/src/emotion.js
@@ -1,11 +1,12 @@
-var request = require('request'),
+var request = require('request').defaults({
+        baseUrl: 'https://api.projectoxford.ai/emotion/v1.0/',
+        headers: {'User-Agent': 'nodejs/0.3.0'}}),
     fs = require('fs'),
     _Promise = require('bluebird');
 
-const emotionUrl = 'https://api.projectoxford.ai/emotion/v1.0/recognize';
+const emotionUrl = '/recognize';
 
-
-var emotion = function(key) {
+var emotion = function (key) {
     /**
      * @private
      */
@@ -14,12 +15,12 @@ var emotion = function(key) {
             return reject(error);
         }
 
-        if (response.statusCode != 200) {
+        if (response.statusCode !== 200) {
             reject(response.body);
         }
 
         return resolve(response.body);
-    };
+    }
 
     /**
      * (Private) Analyze a local image, using a fs pipe
@@ -42,7 +43,7 @@ var emotion = function(key) {
                 _return(error, response, resolve, reject);
             }));
         });
-    };
+    }
 
     /**
      * (Private) Analyze an online image
@@ -64,10 +65,22 @@ var emotion = function(key) {
                 qs: options
             }, (error, response) => _return(error, response, resolve, reject));
         });
-    };
+    }
 
     function analyzeEmotion(options) {
-        let qs = {faceRectangles: options.faceRectangles};
+        let qs = {};
+        if (options && options.faceRectangles) {
+            var rects = [];
+            options.faceRectangles.forEach(function (rect) {
+                var r = [];
+                r.push(rect.left);
+                r.push(rect.top);
+                r.push(rect.width);
+                r.push(rect.height);
+                rects.push(r.join(','));
+            });
+            qs.faceRectangles = rects.join(';');
+        }
 
         if (options.path) {
             return _emotionLocal(options.path, qs);
@@ -75,11 +88,11 @@ var emotion = function(key) {
         if (options.url) {
             return _emotionOnline(options.url, qs);
         }
-    };
+    }
 
     return {
         analyzeEmotion: analyzeEmotion
     };
-}
+};
 
 module.exports = emotion;

--- a/src/vision.js
+++ b/src/vision.js
@@ -1,12 +1,14 @@
-var request = require('request'),
+var request = require('request').defaults({
+        baseUrl: 'https://api.projectoxford.ai/vision/v1/',
+        headers: {'User-Agent': 'nodejs/0.3.0'}}),
     fs = require('fs'),
     _Promise = require('bluebird');
 
-const analyzeUrl = 'https://api.projectoxford.ai/vision/v1/analyses';
-const thumbnailUrl = 'https://api.projectoxford.ai/vision/v1/thumbnails';
-const ocrUrl = 'https://api.projectoxford.ai/vision/v1/ocr';
+const analyzeUrl = '/analyses';
+const thumbnailUrl = '/thumbnails';
+const ocrUrl = '/ocr';
 
-/** 
+/**
  * @namespace
  * @memberof Client
  */
@@ -19,12 +21,12 @@ var vision = function (key) {
             return reject(error);
         }
 
-        if (response.statusCode != 200) {
+        if (response.statusCode !== 200) {
             reject(response.body);
         }
 
         return resolve(response.body);
-    };
+    }
 
     /**
      * (Private) Analyze a local image, using a fs pipe

--- a/test/test.js
+++ b/test/test.js
@@ -7,11 +7,15 @@ var assert = require('assert'),
 
 // Store variables, no point in calling the api too often
 var billFaces = [],
+    billPersistedFaces = [],
     personGroupId = uuid.v4(),
     personGroupId2 = uuid.v4(),
+    personFaceListId = uuid.v4(),
     subValid = true,
-    billPersonId;
+    billPersonId,
+    billPersonPersistedFaceId;
  
+var t0 = [];
 describe('Project Oxford Face API Test', function () {
     afterEach(function() {
         // delay after each test to prevent throttling
@@ -29,14 +33,13 @@ describe('Project Oxford Face API Test', function () {
                 analyzesGender: true,
                 analyzesHeadPose: true
             }).then(function (response) {
-                assert.ok(response[0].faceId);
                 assert.ok(response[0].faceRectangle);
                 assert.ok(response[0].faceLandmarks);
-                assert.ok(response[0].attributes.age);
-                assert.ok(response[0].attributes.gender);
-                assert.ok(response[0].attributes.headPose);
+                assert.ok(response[0].faceAttributes.age);
+                assert.ok(response[0].faceAttributes.gender);
+                assert.ok(response[0].faceAttributes.headPose);
 
-                assert.equal(response[0].attributes.gender, 'male');
+                assert.equal(response[0].faceAttributes.gender, 'male');
                 done();
             }).catch(function (error) {
                 // Check if subscription is valid
@@ -51,6 +54,7 @@ describe('Project Oxford Face API Test', function () {
             this.timeout(30000);
             client.face.detect({
                 path: './test/images/face1.jpg',
+                returnFaceId: true,
                 analyzesFaceLandmarks: true,
                 analyzesAge: true,
                 analyzesGender: true,
@@ -59,10 +63,10 @@ describe('Project Oxford Face API Test', function () {
                 assert.ok(response[0].faceId);
                 assert.ok(response[0].faceRectangle);
                 assert.ok(response[0].faceLandmarks);
-                assert.ok(response[0].attributes.gender);
-                assert.ok(response[0].attributes.headPose);
+                assert.ok(response[0].faceAttributes.gender);
+                assert.ok(response[0].faceAttributes.headPose);
 
-                assert.equal(response[0].attributes.gender, 'male');
+                assert.equal(response[0].faceAttributes.gender, 'male');
                 done();
             });
         });
@@ -71,18 +75,23 @@ describe('Project Oxford Face API Test', function () {
             this.timeout(30000);
             client.face.detect({
                 url: 'https://upload.wikimedia.org/wikipedia/commons/1/19/Bill_Gates_June_2015.jpg',
+                returnFaceId: true,
                 analyzesFaceLandmarks: true,
                 analyzesAge: true,
+                analyzesFacialHair: true,
                 analyzesGender: true,
-                analyzesHeadPose: true
+                analyzesHeadPose: true,
+                analyzesSmile: true
             }).then(function (response) {
                 assert.ok(response[0].faceId);
                 assert.ok(response[0].faceRectangle);
                 assert.ok(response[0].faceLandmarks);
-                assert.ok(response[0].attributes.gender);
-                assert.ok(response[0].attributes.headPose);
+                assert.ok(response[0].faceAttributes.gender);
+                assert.ok(response[0].faceAttributes.headPose);
 
-                assert.equal(response[0].attributes.gender, 'male');
+                assert.equal(response[0].faceAttributes.gender, 'male');
+                assert.ok(response[0].faceAttributes.smile > 0.5);
+                assert.ok(response[0].faceAttributes.facialHair.beard < 0.1);
                 done();
             });
         });
@@ -95,22 +104,29 @@ describe('Project Oxford Face API Test', function () {
             this.timeout(30000);
 
             detects.push(client.face.detect({
-                path: './test/images/face1.jpg',
-            }).then(function(response) {
-                assert.ok(response[0].faceId)
-                billFaces.push(response[0].faceId);
-            }));
+                    path: './test/images/face1.jpg',
+                    returnFaceId: true
+                }).then(function(response) {
+                    assert.ok(response[0].faceId);
+                    billFaces.push(response[0].faceId);
+                })
+            );
 
             detects.push(client.face.detect({
-                path: './test/images/face2.jpg',
-            }).then(function(response) {
-                assert.ok(response[0].faceId)
-                billFaces.push(response[0].faceId);
-            }));
+                    path: './test/images/face2.jpg',
+                    returnFaceId: true
+                }).then(function(response) {
+                    assert.ok(response[0].faceId);
+                    billFaces.push(response[0].faceId);
+                })
+            );
 
             _Promise.all(detects).then(function() {
-                client.face.similar(billFaces[0], [billFaces[1]]).then(function(response) {
-                    assert.ok(response[0].faceId)
+                client.face.similar(billFaces[0], {
+                    candidateFaces: [billFaces[1]]
+                }).then(function(response) {
+                    assert.equal(response[0].faceId, billFaces[1]);
+                    assert.ok(response[0].confidence > 0.5);
                     done();
                 });
             });
@@ -125,6 +141,7 @@ describe('Project Oxford Face API Test', function () {
 
             client.face.detect({
                 path: './test/images/face-group.jpg',
+                returnFaceId: true
             }).then(function(response) {
                 response.forEach(function (face) {
                     faceIds.push(face.faceId);
@@ -155,11 +172,118 @@ describe('Project Oxford Face API Test', function () {
         });
     });
     
+    describe('#faceList', function () {
+        before(function(done) {
+            this.timeout(5000);
+            // Remove old face lists.
+            client.face.faceList.list().then(function (response) {
+                var promises = [];
+
+                response.forEach(function (faceList) {
+                    if (faceList.name.indexOf('po-node-test-face') > -1) {
+                        promises.push(client.face.faceList.delete(faceList.faceListId));
+                    }
+                });
+
+                _Promise.all(promises).then(function () {
+                    done();
+                });
+            });
+        });
+
+        it('creates a face list', function (done) {
+            client.face.faceList.create(personFaceListId, {
+                name: 'po-node-test-face',
+                userData: 'test-data' })
+            .then(function (response) {
+                done();
+            })
+            .catch(function (error) {
+                assert.ok(false, JSON.stringify(error));
+                done();
+            });
+        });
+        
+        it('adds two face to the face list', function (done) {
+            this.timeout(10000);
+            var adds = [];
+            
+            adds.push(client.face.faceList.addFace(personFaceListId, {
+                    path: './test/images/face1.jpg',
+                    name: 'bill-face-1'})
+                .then(function (response) {
+                    billPersistedFaces.push(response.persistedFaceId);
+                })
+                .catch(function (error) {
+                    assert.ok(false, JSON.stringify(error));
+                }));
+                
+            adds.push(client.face.faceList.addFace(personFaceListId, {
+                    url: 'https://upload.wikimedia.org/wikipedia/commons/1/19/Bill_Gates_June_2015.jpg',
+                    name: 'bill-face-2'})
+                .then(function (response) {
+                    billPersistedFaces.push(response.persistedFaceId);
+                })
+                .catch(function (error) {
+                    assert.ok(false, JSON.stringify(error));
+                }));
+                
+            _Promise.all(adds).then(function () {
+                done();
+            })
+        });
+        
+        it('removes one face from the face list', function (done) {
+            assert.equal(billPersistedFaces.length, 2);
+            var persistedFaceId = billPersistedFaces.pop();
+            client.face.faceList.deleteFace(personFaceListId, persistedFaceId)
+            .then(function (response) {
+                assert.ok(true, "void response expected");
+                done();
+            })
+            .catch(function (error) {
+                assert.ok(false, JSON.stringify(error));
+                done();
+            });
+        });
+        
+        it('retrieves the face list', function (done) {
+            client.face.faceList.get(personFaceListId)
+            .then(function (response) {
+                assert.equal(personFaceListId, response.faceListId);
+                assert.equal(response.name, 'po-node-test-face');
+                assert.equal(response.userData, 'test-data');
+                assert.equal(response.persistedFaces.length, 1);
+                assert.equal(response.persistedFaces[0].persistedFaceId, billPersistedFaces[0]);
+                done();
+            })
+            .catch(function (error) {
+                assert.ok(false, JSON.stringify(error));
+                done();
+            });
+        });
+        
+        it('invokes #similar using the face list', function (done) {
+            client.face.similar(billFaces[0], {
+                candidateFaceListId: personFaceListId
+            })
+            .then(function (response) {
+                assert.equal(response.length, 1);
+                assert.equal(response[0].persistedFaceId, billPersistedFaces[0]);
+                done();
+            })
+            .catch(function (error) {
+                assert.ok(false, JSON.stringify(error));
+                done();
+            });
+        });
+    });
+    
     describe('#PersonGroup', function () {
         before(function(done) {
             this.timeout(5000);
             // In order to test the
-            // training feature, we have to start trainign - sadly, we can't
+            // training feature, we have to start training - sadly, we can't
             // delete the group then. So we clean up before we run tests - and to wait
             // for cleanup to finish, we're just using done().
             client.face.personGroup.list().then(function (response) {
@@ -178,7 +302,8 @@ describe('Project Oxford Face API Test', function () {
         });
 
         it('creates a PersonGroup', function (done) {
-            client.face.personGroup.create(personGroupId, 'po-node-test-group', 'test-data').then(function (response) {
+            client.face.personGroup.create(personGroupId, 'po-node-test-group', 'test-data')
+            .then(function (response) {
                 assert.ok(true, "void response expected");
                 done();
             })
@@ -189,7 +314,8 @@ describe('Project Oxford Face API Test', function () {
         });
 
         it('lists PersonGroups', function (done) {
-            client.face.personGroup.list().then(function (response) {
+            client.face.personGroup.list()
+            .then(function (response) {
                 assert.ok(response);
                 assert.ok((response.length > 0));
                 assert.ok(response[0].personGroupId);
@@ -203,11 +329,16 @@ describe('Project Oxford Face API Test', function () {
                 assert.equal(response.name, 'po-node-test-group');
                 assert.equal(response.userData, 'test-data');
                 done();
+            })
+            .catch(function (error) {
+                assert.ok(false, JSON.stringify(error));
+                done();
             });
         });
         
         it('updates a PersonGroup', function (done) {
-            client.face.personGroup.update(personGroupId, 'po-node-test-group2', 'test-data2').then(function (response) {
+            client.face.personGroup.update(personGroupId, 'po-node-test-group2', 'test-data2')
+            .then(function (response) {
                 assert.ok(true, "void response expected");;
                 done();
             }).catch(function (response) {
@@ -216,21 +347,25 @@ describe('Project Oxford Face API Test', function () {
         });
 
         it('gets a PersonGroup\'s training status', function (done) {
-            client.face.personGroup.trainingStatus(personGroupId).then(function (response) {
-                assert.equal(response.code, 'PersonGroupNotTrained');
+            client.face.personGroup.trainingStatus(personGroupId)
+            .then(function (response) {
+                assert.equal(response.personGroupId, personGroupId);
+                assert.equal(response.status, 'notstarted');
                 done();
-            }).catch(function (response) {
-                assert.equal(response.code, 'PersonGroupNotTrained');
+            })
+            .catch(function (error) {
+                assert.equal(error.code, 'PersonGroupNotTrained');
                 done();
             });
         });
 
         it('starts a PersonGroup\'s training', function (done) {
-            client.face.personGroup.trainingStart(personGroupId).then(function (response) {
-                assert.equal(response.status, 'running');
+            client.face.personGroup.trainingStart(personGroupId)
+            .then(function (response) {
+                assert.ok(true, "void response expected");;
                 done();
-            }).catch(function (response) {
-                assert.equal(response.status, 'running');
+            }).catch(function (error) {
+                assert.ok(false, JSON.stringify(error));
                 done();
             });
         });
@@ -240,7 +375,7 @@ describe('Project Oxford Face API Test', function () {
                 assert.ok(!response, "void response");
                 done();
             }).catch(function (response) {
-                assert.equal(JSON.parse(response).code, 'PersonGroupTrainingNotFinished');
+                assert.equal(JSON.parse(response).error.code, 'PersonGroupTrainingNotFinished');
                 done();
             });
         });
@@ -261,7 +396,7 @@ describe('Project Oxford Face API Test', function () {
         });
 
         it('creates a Person', function (done) {
-            client.face.person.create(personGroupId2, [billFaces[0]], 'test-bill', 'test-data')
+            client.face.person.create(personGroupId2, 'test-bill', 'test-data')
             .then(function (response) {
                 assert.ok(response.personId);
                 billPersonId = response.personId;
@@ -274,40 +409,11 @@ describe('Project Oxford Face API Test', function () {
         });
 
         it('gets a Person', function (done) {
-            client.face.person.get(personGroupId2, billPersonId).then(function (response) {
-                assert.ok(response.personId);
-                done();
-            })
-            .catch(function (error) {
-                assert.ok(false, JSON.stringify(error));
-                done();
-            });
-        });
-
-        it('updates a Person', function (done) {
-            client.face.person.update(personGroupId2, billPersonId, [billFaces[0]], 'test-bill', 'test-data')
+            client.face.person.get(personGroupId2, billPersonId)
             .then(function (response) {
-                assert.ok(true, "void response expected");
-                done();
-            })
-        });
-
-        it('adds a face to a Person', function (done) {
-            client.face.person.addFace(personGroupId2, billPersonId, billFaces[1], 'test-data')
-            .then(function (response) {
-                assert.ok(true, "void response expected");
-                done();
-            })
-            .catch(function (error) {
-                assert.ok(false, JSON.stringify(error));
-                done();
-            });
-        });
-
-        it('gets a face from a Person', function (done) {
-            client.face.person.getFace(personGroupId2, billPersonId, billFaces[1])
-            .then(function (response) {
-                assert.ok(response.userData);
+                assert.equal(response.personId, billPersonId);
+                assert.ok(!response.persistedFaceIds || response.persistedFaceIds.length, 0);
+                assert.equal(response.name, 'test-bill');
                 assert.equal(response.userData, 'test-data');
                 done();
             })
@@ -317,8 +423,49 @@ describe('Project Oxford Face API Test', function () {
             });
         });
 
+        it('updates a Person', function (done) {
+            client.face.person.update(personGroupId2, billPersonId, 'test-bill2', 'test-data2')
+            .then(function (response) {
+                assert.ok(true, "void response expected");
+                done();
+            })
+            .catch(function (error) {
+                assert.ok(false, JSON.stringify(error));
+                done();
+            });
+        });
+
+        it('adds a face to a Person', function (done) {
+            client.face.person.addFace(personGroupId2, billPersonId, {
+                path: './test/images/face1.jpg',
+                userData: 'test-data-face'
+            })
+            .then(function (response) {
+                billPersonPersistedFaceId = response.persistedFaceId;
+                assert.ok(billPersonPersistedFaceId);
+                done();
+            })
+            .catch(function (error) {
+                assert.ok(false, JSON.stringify(error));
+                done();
+            });
+        });
+
+        it('gets a face from a Person', function (done) {
+            client.face.person.getFace(personGroupId2, billPersonId, billPersonPersistedFaceId)
+            .then(function (response) {
+                assert.equal(response.persistedFaceId, billPersonPersistedFaceId);
+                assert.equal(response.userData, 'test-data-face');
+                done();
+            })
+            .catch(function (error) {
+                assert.ok(false, JSON.stringify(error));
+                done();
+            });
+        });
+
         it('updates a face on a Person', function (done) {
-            client.face.person.updateFace(personGroupId2, billPersonId, billFaces[1], 'test-data')
+            client.face.person.updateFace(personGroupId2, billPersonId, billPersonPersistedFaceId, 'test-data-face-updated')
             .then(function (response) {
                 assert.ok(true, "void response expected");
                 done();
@@ -330,7 +477,7 @@ describe('Project Oxford Face API Test', function () {
         });
 
         it('deletes a face on a Person', function (done) {
-            client.face.person.deleteFace(personGroupId2, billPersonId, billFaces[1])
+            client.face.person.deleteFace(personGroupId2, billPersonId, billPersonPersistedFaceId)
             .then(function (response) {
                 assert.ok(true, "void response expected");
                 done();
@@ -344,7 +491,11 @@ describe('Project Oxford Face API Test', function () {
         it('lists Persons', function (done) {
             client.face.person.list(personGroupId2)
             .then(function (response) {
-                assert.ok(response[0].personId);
+                assert.equal(response.length, 1);
+                assert.equal(response[0].personId, billPersonId);
+                assert.equal(response[0].name, 'test-bill2');
+                assert.equal(response[0].userData, 'test-data2');
+                assert.ok(!response[0].persistedFaceIds || response[0].persistedFaceIds.length == 0);
                 done();
             })
             .catch(function (error) {
@@ -492,5 +643,45 @@ describe('Project Oxford Vision API Test', function () {
             assert.ok(response.orientation);
             done();
         });
+    });
+});
+
+describe('Project Oxford Emotion API Test', function () {
+    it('analyzes a local image', function (done) {
+        this.timeout(30000);
+        client.emotion.analyzeEmotion({
+            path: './test/images/face2.jpg'
+        })
+        .then(function (response) {
+            assert.ok(response);
+            assert.equal(response.length, 1);
+            assert.ok(response[0].faceRectangle);
+            var highestEmotion;
+            var highestScore = 0;
+            for (var emotion in response[0].scores) {
+                var score = response[0].scores[emotion];
+                if (score > highestScore) {
+                    highestScore = score;
+                    highestEmotion = emotion;
+                }
+            }
+            assert.equal(highestEmotion, 'happiness');
+            done();
+        })
+    });
+
+    it('analyzes an online image', function (done) {
+        this.timeout(30000);
+        client.emotion.analyzeEmotion({
+            url: 'https://upload.wikimedia.org/wikipedia/commons/thumb/c/c0/Crying-girl.jpg/640px-Crying-girl.jpg',
+            faceRectangles: [{left: 167, top: 163, width: 224, height: 224}]
+        })
+        .then(function (response) {
+            assert.ok(response);
+            assert.equal(response.length, 1);
+            assert.ok(response[0].faceRectangle);
+            assert.ok(response[0].scores.sadness > 0.98);
+            done();
+        })
     });
 });


### PR DESCRIPTION
This is a BREAKING CHANGE.  Notes:

- Be warned that v1 IDs are not compatible with the v0 API.  If you've
  squirreled away these IDs, you will need to retrain your PersonGroup. 
- The concept of a FaceList has been introduced.  This is a collection of
  face IDs that you would typically associate with a Person in a
  PersonGroup.
- The concept of persistedFaceIds has been introduced.  These IDs are
  long-lived, and are used for training.  By contrast, a plain faceId is
  a byproduct of face feature detection.  Note that face.detect method no
  longer returns a faceId by default.  If you are interested in getting a
  faceId, you must request it in the options `{returnFaceId: true}`.
- You can get a persistedFaceId either via faceList.addFace or
  person.addFace.
- A UA string was added for server-side analytics.
- Emotion API did not handle rectangles as input correctly, now they do.
- Emotion API now has some tests.