### PR TITLE
Add Tags and Description to Vision API (analyzeImage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -783,6 +783,8 @@ set of rich visual features based on the image content.
 | options.Faces | <code>boolean</code> | Detects if faces are present. If present, generate coordinates, gender and age. |
 | options.Adult | <code>boolean</code> | Detects if image is pornographic in nature (nudity or sex act). Sexually suggestive content is also detected. |
 | options.Categories | <code>boolean</code> | Image categorization; taxonomy defined in documentation. |
+| options.Tags | <code>boolean</code> | Tags the image with a detailed list of words related to the image content. |
+| options.Description | <code>boolean</code> | Describes the image content with a complete English sentence. |
 
 <a name="Client.vision..thumbnail"></a>
 #### vision~thumbnail(options) ⇒ <code>Promise</code>

--- a/dist/vision.js
+++ b/dist/vision.js
@@ -86,17 +86,19 @@ var vision = function vision(key) {
      * @param  {boolean} options.Faces          - Detects if faces are present. If present, generate coordinates, gender and age.
      * @param  {boolean} options.Adult          - Detects if image is pornographic in nature (nudity or sex act). Sexually suggestive content is also detected.
      * @param  {boolean} options.Categories     - Image categorization; taxonomy defined in documentation.
+     * @param  {boolean} options.Tags           - Tags the image with a detailed list of words related to the image content.
+     * @param  {boolean} options.Description    - Describes the image content with a complete English sentence.
      * @return {Promise}                        - Promise resolving with the resulting JSON
      */
     function analyzeImage(options) {
-        var test = /(ImageType)|(Color)|(Faces)|(Adult)|(Categories)/;
+        var test = /(ImageType)|(Color)|(Faces)|(Adult)|(Categories)|(Tags)|(Description)/;
         var query = [];
 
-        Object.keys(options).forEach(function (value, key) {
-            if (key.toString().match(test) && value) {
-                query.push(key.toString());
+        for (var key in options) {
+            if (test.test(key) && options[key]) {
+                query.push(key);
             }
-        });
+        };
 
         var qs = { visualFeatures: query.join() };
 

--- a/src/vision.js
+++ b/src/vision.js
@@ -91,7 +91,7 @@ var vision = function (key) {
         let query = [];
 
         for (var key in options) {
-            if (test.test(key)&& options[key]) {
+            if (test.test(key) && options[key]) {
                 query.push(key);
             }
         };

--- a/src/vision.js
+++ b/src/vision.js
@@ -82,17 +82,19 @@ var vision = function (key) {
      * @param  {boolean} options.Faces          - Detects if faces are present. If present, generate coordinates, gender and age.
      * @param  {boolean} options.Adult          - Detects if image is pornographic in nature (nudity or sex act). Sexually suggestive content is also detected.
      * @param  {boolean} options.Categories     - Image categorization; taxonomy defined in documentation.
+     * @param  {boolean} options.Tags           - Tags the image with a detailed list of words related to the image content.
+     * @param  {boolean} options.Description    - Describes the image content with a complete English sentence.
      * @return {Promise}                        - Promise resolving with the resulting JSON
      */
     function analyzeImage(options) {
-        let test = /(ImageType)|(Color)|(Faces)|(Adult)|(Categories)/;
+        let test = /(ImageType)|(Color)|(Faces)|(Adult)|(Categories)|(Tags)|(Description)/;
         let query = [];
 
-        Object.keys(options).forEach((value, key) => {
-            if (key.toString().match(test) && value) {
-                query.push(key.toString());
+        for (var key in options) {
+            if (test.test(key)&& options[key]) {
+                query.push(key);
             }
-        });
+        };
 
         let qs = {visualFeatures: query.join()};
 

--- a/test/test.js
+++ b/test/test.js
@@ -544,7 +544,9 @@ describe('Project Oxford Vision API Test', function () {
             Color: true,
             Faces: true,
             Adult: true,
-            Categories: true
+            Categories: true,
+            Tags: true,
+            Description: true
         })
         .then(function (response) {
             assert.ok(response);
@@ -554,6 +556,8 @@ describe('Project Oxford Vision API Test', function () {
             assert.ok(response.faces);
             assert.ok(response.color);
             assert.ok(response.imageType);
+            assert.ok(response.tags);
+            assert.ok(response.description);
             done();
         })
     });
@@ -573,7 +577,9 @@ describe('Project Oxford Vision API Test', function () {
             Color: true,
             Faces: true,
             Adult: true,
-            Categories: true
+            Categories: true,
+            Tags: true,
+            Description: true
         })
         .then(function (response) {
             assert.ok(response);
@@ -583,6 +589,8 @@ describe('Project Oxford Vision API Test', function () {
             assert.ok(response.faces);
             assert.ok(response.color);
             assert.ok(response.imageType);
+            assert.ok(response.tags);
+            assert.ok(response.description);
             done();
         });
     });


### PR DESCRIPTION
I have included the tags and descriptions as options to analyzeImage. Although they are available on [Vision API](https://dev.projectoxford.ai/docs/services/56f91f2d778daf23d8ec6739/operations/56f91f2e778daf14a499e1fa), vision.js did not return such information. 