### PR TITLE
Target face support for adding face to a facelist

### DIFF
--- a/src/face.js
+++ b/src/face.js
@@ -406,6 +406,7 @@ var face = function (key) {
          * @param  {stream} options.stream      - Stream for image to be used
          * @param  {string} options.name        - Optional name for the face
          * @param  {string} options.userData    - Optional user-data for the face
+		  * @param  {string} options.targetFace  - Optional face rectangle to specify the target face to be added into the face list, in the format of "targetFace=left,top,width,height".
          * @return {Promise}                    - Promise resolving with the resulting JSON
          */
         addFace: function (faceListId, options) {
@@ -414,6 +415,7 @@ var face = function (key) {
             if (options) {
                 qs.name = options.name;
                 qs.userData = options.userData;
+				 qs.targetFace = options.targetFace;
             }
             return _postImage(url, options, qs);
         },

--- a/src/face.js
+++ b/src/face.js
@@ -406,7 +406,7 @@ var face = function (key) {
          * @param  {stream} options.stream      - Stream for image to be used
          * @param  {string} options.name        - Optional name for the face
          * @param  {string} options.userData    - Optional user-data for the face
-		  * @param  {string} options.targetFace  - Optional face rectangle to specify the target face to be added into the face list, in the format of "targetFace=left,top,width,height".
+         * @param  {string} options.targetFace  - Optional face rectangle to specify the target face to be added into the face list, in the format of "targetFace=left,top,width,height".
          * @return {Promise}                    - Promise resolving with the resulting JSON
          */
         addFace: function (faceListId, options) {
@@ -415,7 +415,7 @@ var face = function (key) {
             if (options) {
                 qs.name = options.name;
                 qs.userData = options.userData;
-				 qs.targetFace = options.targetFace;
+                qs.targetFace = options.targetFace;
             }
             return _postImage(url, options, qs);
         },


### PR DESCRIPTION
Current implementation of _face.faceList.addFace_ is lacking support of _targetFace_ optional parameter. This makes impossible to add photos with more than one face. This change would fix it.