### PR TITLE
Allow clients to be created against alternate hosts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ For the full documentation, please see the API reference below.
 **Kind**: global class  
 
 * [Client](#Client)
-    * [new Client(key)](#new_Client_new)
+    * [new Client(key, host)](#new_Client_new)
     * [.emotion](#Client.emotion) : <code>object</code>
         * [~analyzeEmotion(options)](#Client.emotion..analyzeEmotion) ⇒ <code>Promise</code>
     * [.face](#Client.face) : <code>object</code>
@@ -146,13 +146,14 @@ For the full documentation, please see the API reference below.
 
 <a name="new_Client_new"></a>
 
-### new Client(key)
+### new Client(key, host)
 Creates a new Project Oxford Client using a given API key.
 
 
 | Param | Type | Description |
 | --- | --- | --- |
 | key | <code>string</code> | Project Oxford API Key |
+| host | <code>string</code> | Optional host address |
 
 <a name="Client.emotion"></a>
 
@@ -237,7 +238,8 @@ Lists the faceListIds, and associated names and/or userData.
 <a name="Client.face.faceList.create"></a>
 
 ##### faceList.create(faceListId, options) ⇒ <code>Promise</code>
-Creates a new face list with a user-specified ID.A face list is a list of faces associated to be associated with a given person.
+Creates a new face list with a user-specified ID.
+A face list is a list of faces associated to be associated with a given person.
 
 **Kind**: static method of <code>[faceList](#Client.face.faceList)</code>  
 **Returns**: <code>Promise</code> - - Promise resolving with the resulting JSON  
@@ -252,7 +254,9 @@ Creates a new face list with a user-specified ID.A face list is a list of faces
 <a name="Client.face.faceList.update"></a>
 
 ##### faceList.update(faceListId, options) ⇒ <code>Promise</code>
-Creates a new person group with a user-specified ID.A person group is one of the most important parameters for the Identification API.The Identification searches person faces in a specified person group.
+Creates a new person group with a user-specified ID.
+A person group is one of the most important parameters for the Identification API.
+The Identification searches person faces in a specified person group.
 
 **Kind**: static method of <code>[faceList](#Client.face.faceList)</code>  
 **Returns**: <code>Promise</code> - - Promise resolving with the resulting JSON  
@@ -310,7 +314,8 @@ Gets an existing face list.
 <a name="Client.face.faceList.deleteFace"></a>
 
 ##### faceList.deleteFace(faceListId, persistedFaceId) ⇒ <code>Promise</code>
-Delete a face from the face list.  The face ID will be an ID returned in the addFace method,not from the detect method.
+Delete a face from the face list.  The face ID will be an ID returned in the addFace method,
+not from the detect method.
 
 **Kind**: static method of <code>[faceList](#Client.face.faceList)</code>  
 **Returns**: <code>Promise</code> - - Promise; successful response is empty  
@@ -337,7 +342,9 @@ Delete a face from the face list.  The face ID will be an ID returned in the add
 <a name="Client.face.personGroup.create"></a>
 
 ##### personGroup.create(personGroupId, name, userData) ⇒ <code>Promise</code>
-Creates a new person group with a user-specified ID.A person group is one of the most important parameters for the Identification API.The Identification searches person faces in a specified person group.
+Creates a new person group with a user-specified ID.
+A person group is one of the most important parameters for the Identification API.
+The Identification searches person faces in a specified person group.
 
 **Kind**: static method of <code>[personGroup](#Client.face.personGroup)</code>  
 **Returns**: <code>Promise</code> - - Promise resolving with the resulting JSON  
@@ -375,7 +382,9 @@ Gets an existing person group.
 <a name="Client.face.personGroup.trainingStatus"></a>
 
 ##### personGroup.trainingStatus(personGroupId) ⇒ <code>Promise</code>
-Retrieves the training status of a person group. Training is triggered by the Train PersonGroup API.The training will process for a while on the server side. This API can query whether the trainingis completed or ongoing.
+Retrieves the training status of a person group. Training is triggered by the Train PersonGroup API.
+The training will process for a while on the server side. This API can query whether the training
+is completed or ongoing.
 
 **Kind**: static method of <code>[personGroup](#Client.face.personGroup)</code>  
 **Returns**: <code>Promise</code> - - Promise resolving with the resulting JSON  
@@ -387,7 +396,10 @@ Retrieves the training status of a person group. Training is triggered by the Tr
 <a name="Client.face.personGroup.trainingStart"></a>
 
 ##### personGroup.trainingStart(personGroupId) ⇒ <code>Promise</code>
-Starts a person group training.Training is a necessary preparation process of a person group before identification.Each person group needs to be trained in order to call Identification. The trainingwill process for a while on the server side even after this API has responded.
+Starts a person group training.
+Training is a necessary preparation process of a person group before identification.
+Each person group needs to be trained in order to call Identification. The training
+will process for a while on the server side even after this API has responded.
 
 **Kind**: static method of <code>[personGroup](#Client.face.personGroup)</code>  
 **Returns**: <code>Promise</code> - - Promise resolving with the resulting JSON  
@@ -498,7 +510,8 @@ Get a face for a person.
 <a name="Client.face.person.create"></a>
 
 ##### person.create(personGroupId, name, userData) ⇒ <code>Promise</code>
-Creates a new person in a specified person group for identification.The number of persons has a subscription limit. Free subscription amount is 1000 persons.
+Creates a new person in a specified person group for identification.
+The number of persons has a subscription limit. Free subscription amount is 1000 persons.
 
 **Kind**: static method of <code>[person](#Client.face.person)</code>  
 **Returns**: <code>Promise</code> - - Promise resolving with the resulting JSON  
@@ -564,7 +577,11 @@ Lists all persons in a person group, with the person information.
 <a name="Client.face..detect"></a>
 
 #### face~detect(options) ⇒ <code>Promise</code>
-Call the Face Detected APIDetects human faces in an image and returns face locations, face landmarks, andoptional attributes including head-pose, gender, and age. Detection is an essentialAPI that provides faceId to other APIs like Identification, Verification,and Find Similar.
+Call the Face Detected API
+Detects human faces in an image and returns face locations, face landmarks, and
+optional attributes including head-pose, gender, and age. Detection is an essential
+API that provides faceId to other APIs like Identification, Verification,
+and Find Similar.
 
 **Kind**: inner method of <code>[face](#Client.face)</code>  
 **Returns**: <code>Promise</code> - - Promise resolving with the resulting JSON  
@@ -586,7 +603,8 @@ Call the Face Detected APIDetects human faces in an image and returns face loca
 <a name="Client.face..similar"></a>
 
 #### face~similar(sourceFace, options) ⇒ <code>Promise</code>
-Detect similar faces using faceIds (as returned from the detect API), or faceListId(as returned from the facelist API).
+Detect similar faces using faceIds (as returned from the detect API), or faceListId
+(as returned from the facelist API).
 
 **Kind**: inner method of <code>[face](#Client.face)</code>  
 **Returns**: <code>Promise</code> - - Promise resolving with the resulting JSON  
@@ -602,7 +620,15 @@ Detect similar faces using faceIds (as returned from the detect API), or faceLis
 <a name="Client.face..grouping"></a>
 
 #### face~grouping(faces) ⇒ <code>Promise</code>
-Divides candidate faces into groups based on face similarity using faceIds.The output is one or more disjointed face groups and a MessyGroup.A face group contains the faces that have similar looking, often of the same person.There will be one or more face groups ranked by group size, i.e. number of face.Faces belonging to the same person might be split into several groups in the result.The MessyGroup is a special face group that each face is not similar to any otherfaces in original candidate faces. The messyGroup will not appear in the result ifall faces found their similar counterparts. The candidate face list has alimit of 100 faces.
+Divides candidate faces into groups based on face similarity using faceIds.
+The output is one or more disjointed face groups and a MessyGroup.
+A face group contains the faces that have similar looking, often of the same person.
+There will be one or more face groups ranked by group size, i.e. number of face.
+Faces belonging to the same person might be split into several groups in the result.
+The MessyGroup is a special face group that each face is not similar to any other
+faces in original candidate faces. The messyGroup will not appear in the result if
+all faces found their similar counterparts. The candidate face list has a
+limit of 100 faces.
 
 **Kind**: inner method of <code>[face](#Client.face)</code>  
 **Returns**: <code>Promise</code> - - Promise resolving with the resulting JSON  
@@ -614,7 +640,12 @@ Divides candidate faces into groups based on face similarity using faceIds.The 
 <a name="Client.face..identify"></a>
 
 #### face~identify(faces, personGroupId, maxNumOfCandidatesReturned) ⇒ <code>Promise</code>
-Identifies persons from a person group by one or more input faces.To recognize which person a face belongs to, Face Identification needs a person groupthat contains number of persons. Each person contains one or more faces. After a persongroup prepared, it should be trained to make it ready for identification. Then theidentification API compares the input face to those persons' faces in person group andreturns the best-matched candidate persons, ranked by confidence.
+Identifies persons from a person group by one or more input faces.
+To recognize which person a face belongs to, Face Identification needs a person group
+that contains number of persons. Each person contains one or more faces. After a person
+group prepared, it should be trained to make it ready for identification. Then the
+identification API compares the input face to those persons' faces in person group and
+returns the best-matched candidate persons, ranked by confidence.
 
 **Kind**: inner method of <code>[face](#Client.face)</code>  
 **Returns**: <code>Promise</code> - - Promise resolving with the resulting JSON  
@@ -628,7 +659,9 @@ Identifies persons from a person group by one or more input faces.To recognize 
 <a name="Client.face..verify"></a>
 
 #### face~verify(faces) ⇒ <code>Promise</code>
-Analyzes two faces and determine whether they are from the same person.Verification works well for frontal and near-frontal faces.For the scenarios that are sensitive to accuracy please use with own judgment.
+Analyzes two faces and determine whether they are from the same person.
+Verification works well for frontal and near-frontal faces.
+For the scenarios that are sensitive to accuracy please use with own judgment.
 
 **Kind**: inner method of <code>[face](#Client.face)</code>  
 **Returns**: <code>Promise</code> - - Promise resolving with the resulting JSON  
@@ -649,7 +682,8 @@ Analyzes two faces and determine whether they are from the same person.Verifica
 <a name="Client.text..proof"></a>
 
 #### text~proof(text, preContextText, postContextText) ⇒ <code>Promise</code>
-Proofs a word or phrase.  Offers Microsoft Office Word-like spelling corrections. Longer phrases canbe checked, and the result will include casing corrections while avoiding aggressive corrections.
+Proofs a word or phrase.  Offers Microsoft Office Word-like spelling corrections. Longer phrases can
+be checked, and the result will include casing corrections while avoiding aggressive corrections.
 
 **Kind**: inner method of <code>[text](#Client.text)</code>  
 **Returns**: <code>Promise</code> - - A promise in which the resulting JSON is returned.  
@@ -663,7 +697,9 @@ Proofs a word or phrase.  Offers Microsoft Office Word-like spelling corrections
 <a name="Client.text..spellCheck"></a>
 
 #### text~spellCheck(text, preContextText, postContextText) ⇒ <code>Promise</code>
-Spell checks a word or phrase.  Spell checks offers search-engine-like corrections.  Short phrases(up to 9 tokens) will be checked, and the result will be optimized for search queries, both in termsof performance and relevance.
+Spell checks a word or phrase.  Spell checks offers search-engine-like corrections.  Short phrases
+(up to 9 tokens) will be checked, and the result will be optimized for search queries, both in terms
+of performance and relevance.
 
 **Kind**: inner method of <code>[text](#Client.text)</code>  
 **Returns**: <code>Promise</code> - - A promise in which the resulting JSON is returned.  
@@ -701,7 +737,12 @@ Spell checks a word or phrase.  Spell checks offers search-engine-like correctio
 <a name="Client.video.result.get"></a>
 
 ##### result.get(operation) ⇒ <code>Promise</code>
-Checks the result of a given operation.  When an operation is deemed completed, thestatus of the returned object should be 'Succeeded' (or, possibly, 'Failed'.) Foroperations which return a JSON payload, the stringified-JSON is returned in theprocessingResult field.  For operations which return a video, the location of thevideo is provided in the resourceLocation field.  You can use the [getVideo](Client.video.result#getVideo) methodto help you retrieve that, as this would automatically attach the API key to request.
+Checks the result of a given operation.  When an operation is deemed completed, the
+status of the returned object should be 'Succeeded' (or, possibly, 'Failed'.) For
+operations which return a JSON payload, the stringified-JSON is returned in the
+processingResult field.  For operations which return a video, the location of the
+video is provided in the resourceLocation field.  You can use the [getVideo](Client.video.result#getVideo) method
+to help you retrieve that, as this would automatically attach the API key to request.
 
 **Kind**: static method of <code>[result](#Client.video.result)</code>  
 **Returns**: <code>Promise</code> - - Promise resolving with the resulting JSON  
@@ -713,7 +754,8 @@ Checks the result of a given operation.  When an operation is deemed completed, 
 <a name="Client.video.result.getVideo"></a>
 
 ##### result.getVideo(url, pipe) ⇒ <code>Promise</code>
-Downloads the resulting video, for processors that returning videos instead of metadata.Currently this applies to the [stabilize](Client.video#stabilize) operation.
+Downloads the resulting video, for processors that returning videos instead of metadata.
+Currently this applies to the [stabilize](Client.video#stabilize) operation.
 
 **Kind**: static method of <code>[result](#Client.video.result)</code>  
 **Returns**: <code>Promise</code> - - Promise resolving with the resulting video  
@@ -726,7 +768,8 @@ Downloads the resulting video, for processors that returning videos instead of m
 <a name="Client.video..trackFace"></a>
 
 #### video~trackFace(options) ⇒ <code>Promise</code>
-Start a face-tracking processorFaces in a video will be tracked.
+Start a face-tracking processor
+Faces in a video will be tracked.
 
 **Kind**: inner method of <code>[video](#Client.video)</code>  
 **Returns**: <code>Promise</code> - - Promise resolving with the resulting JSON  
@@ -741,7 +784,8 @@ Start a face-tracking processorFaces in a video will be tracked.
 <a name="Client.video..detectMotion"></a>
 
 #### video~detectMotion(options) ⇒ <code>Promise</code>
-Start a motion-tracking processorMotion in a video will be tracked.
+Start a motion-tracking processor
+Motion in a video will be tracked.
 
 **Kind**: inner method of <code>[video](#Client.video)</code>  
 **Returns**: <code>Promise</code> - - Promise resolving with the resulting JSON  
@@ -756,7 +800,8 @@ Start a motion-tracking processorMotion in a video will be tracked.
 <a name="Client.video..stabilize"></a>
 
 #### video~stabilize(options) ⇒ <code>Promise</code>
-Start a stablization processorA stabilized version of you video will be generated.
+Start a stablization processor
+A stabilized version of you video will be generated.
 
 **Kind**: inner method of <code>[video](#Client.video)</code>  
 **Returns**: <code>Promise</code> - - Promise resolving with the resulting JSON  
@@ -817,7 +862,8 @@ Analyze an image using a domain-specific image classifier.
 <a name="Client.vision..analyzeImage"></a>
 
 #### vision~analyzeImage(options) ⇒ <code>Promise</code>
-This operation does a deep analysis on the given image and then extracts aset of rich visual features based on the image content.
+This operation does a deep analysis on the given image and then extracts a
+set of rich visual features based on the image content.
 
 **Kind**: inner method of <code>[vision](#Client.vision)</code>  
 **Returns**: <code>Promise</code> - - Promise resolving with the resulting JSON  
@@ -838,7 +884,10 @@ This operation does a deep analysis on the given image and then extracts aset o
 <a name="Client.vision..thumbnail"></a>
 
 #### vision~thumbnail(options) ⇒ <code>Promise</code>
-Generate a thumbnail image to the user-specified width and height. By default, theservice analyzes the image, identifies the region of interest (ROI), and generatessmart crop coordinates based on the ROI. Smart cropping is designed to help when youspecify an aspect ratio that differs from the input image.
+Generate a thumbnail image to the user-specified width and height. By default, the
+service analyzes the image, identifies the region of interest (ROI), and generates
+smart crop coordinates based on the ROI. Smart cropping is designed to help when you
+specify an aspect ratio that differs from the input image.
 
 **Kind**: inner method of <code>[vision](#Client.vision)</code>  
 **Returns**: <code>Promise</code> - - Promise resolving with the resulting JSON  
@@ -856,7 +905,8 @@ Generate a thumbnail image to the user-specified width and height. By default, t
 <a name="Client.vision..ocr"></a>
 
 #### vision~ocr(options) ⇒ <code>Promise</code>
-Optical Character Recognition (OCR) detects text in an image and extracts the recognizedcharacters into a machine-usable character stream.
+Optical Character Recognition (OCR) detects text in an image and extracts the recognized
+characters into a machine-usable character stream.
 
 **Kind**: inner method of <code>[vision](#Client.vision)</code>  
 **Returns**: <code>Promise</code> - - Promise resolving with the resulting JSON  

--- a/dist/emotion.js
+++ b/dist/emotion.js
@@ -1,18 +1,18 @@
 'use strict';
 
 var request = require('request').defaults({
-    baseUrl: 'https://api.projectoxford.ai/emotion/v1.0/',
-    headers: { 'User-Agent': 'nodejs/0.3.0' } }),
+    headers: { 'User-Agent': 'nodejs/0.4.0' } }),
     fs = require('fs'),
     _Promise = require('bluebird');
 
-var emotionUrl = '/recognize';
+var rootPath = '/emotion/v1.0';
+var recognizePath = '/recognize';
 
 /**
  * @namespace
  * @memberof Client
  */
-var emotion = function emotion(key) {
+var emotion = function emotion(key, host) {
     /**
      * @private
      */
@@ -37,17 +37,19 @@ var emotion = function emotion(key) {
      */
     function _emotionLocal(image, options) {
         return new _Promise(function (resolve, reject) {
-            fs.createReadStream(image).pipe(request.post({
-                uri: emotionUrl,
+            /*fs.createReadStream(image).pipe(*/
+            request.post({
+                uri: host + rootPath + recognizePath,
                 headers: {
                     'Ocp-Apim-Subscription-Key': key,
                     'Content-Type': 'application/octet-stream'
                 },
-                qs: options
+                qs: options,
+                body: fs.readFileSync(image)
             }, function (error, response) {
                 response.body = JSON.parse(response.body);
                 _return(error, response, resolve, reject);
-            }));
+            });
         });
     }
 
@@ -58,10 +60,10 @@ var emotion = function emotion(key) {
      * @param  {Object} options     - Options object
      * @return {Promise}            - Promise resolving with the resulting JSON
      */
-    function _emotionOnline(image, options) {
+    /*)*/function _emotionOnline(image, options) {
         return new _Promise(function (resolve, reject) {
             request.post({
-                uri: emotionUrl,
+                uri: host + rootPath + recognizePath,
                 headers: {
                     'Ocp-Apim-Subscription-Key': key,
                     'Content-Type': 'application/json'

--- a/dist/face.js
+++ b/dist/face.js
@@ -1,25 +1,25 @@
 'use strict';
 
 var request = require('request').defaults({
-    baseUrl: 'https://api.projectoxford.ai/face/v1.0/',
-    headers: { 'User-Agent': 'nodejs/0.3.0' } }),
+    headers: { 'User-Agent': 'nodejs/0.4.0' } }),
     fs = require('fs'),
     _Promise = require('bluebird');
 
-var detectUrl = '/detect';
-var similarUrl = '/findsimilars';
-var groupingUrl = '/group';
-var identifyUrl = '/identify';
-var verifyUrl = '/verify';
-var personGroupUrl = '/persongroups';
-var personUrl = '/persongroups';
-var faceListUrl = '/facelists';
+var rootPath = '/face/v1.0';
+var detectPath = '/detect';
+var similarPath = '/findsimilars';
+var groupingPath = '/group';
+var identifyPath = '/identify';
+var verifyPath = '/verify';
+var personGroupPath = '/persongroups';
+var personPath = '/persongroups';
+var faceListPath = '/facelists';
 
 /**
  * @namespace
  * @memberof Client
  */
-var face = function face(key) {
+var face = function face(key, host) {
     /**
      * @private
      */
@@ -47,7 +47,7 @@ var face = function face(key) {
     function _postOnline(url, image, options) {
         return new _Promise(function (resolve, reject) {
             request.post({
-                uri: url,
+                uri: host + rootPath + url,
                 headers: { 'Ocp-Apim-Subscription-Key': key },
                 json: true,
                 body: { url: image },
@@ -70,7 +70,7 @@ var face = function face(key) {
     function _postImageSync(url, image, options) {
         return new _Promise(function (resolve, reject) {
             request.post({
-                uri: url,
+                uri: host + rootPath + url,
                 headers: {
                     'Ocp-Apim-Subscription-Key': key,
                     'Content-Type': 'application/octet-stream'
@@ -99,7 +99,7 @@ var face = function face(key) {
     function _postBuffer(url, buffer, options) {
         return new _Promise(function (resolve, reject) {
             request.post({
-                uri: url,
+                uri: host + rootPath + url,
                 headers: {
                     'Ocp-Apim-Subscription-Key': key,
                     'Content-Type': 'application/octet-stream' },
@@ -178,7 +178,7 @@ var face = function face(key) {
             returnFaceAttributes: attributes.join()
         };
 
-        return _postImage(detectUrl, options, qs);
+        return _postImage(detectPath, options, qs);
     }
 
     /**
@@ -207,7 +207,7 @@ var face = function face(key) {
                 }
             }
             request.post({
-                uri: similarUrl,
+                uri: host + rootPath + similarPath,
                 headers: { 'Ocp-Apim-Subscription-Key': key },
                 json: true,
                 body: faces
@@ -238,7 +238,7 @@ var face = function face(key) {
             }
 
             request.post({
-                uri: groupingUrl,
+                uri: host + rootPath + groupingPath,
                 headers: { 'Ocp-Apim-Subscription-Key': key },
                 json: true,
                 body: faces
@@ -270,7 +270,7 @@ var face = function face(key) {
             };
 
             request.post({
-                uri: identifyUrl,
+                uri: host + rootPath + identifyPath,
                 headers: { 'Ocp-Apim-Subscription-Key': key },
                 json: true,
                 body: body
@@ -296,7 +296,7 @@ var face = function face(key) {
                 };
 
                 request.post({
-                    uri: verifyUrl,
+                    uri: host + rootPath + verifyPath,
                     headers: { 'Ocp-Apim-Subscription-Key': key },
                     json: true,
                     body: body
@@ -321,7 +321,7 @@ var face = function face(key) {
         list: function list() {
             return new _Promise(function (resolve, reject) {
                 request({
-                    uri: faceListUrl,
+                    uri: host + rootPath + faceListPath,
                     headers: { 'Ocp-Apim-Subscription-Key': key }
                 }, function (error, response) {
                     response.body = JSON.parse(response.body);
@@ -348,7 +348,7 @@ var face = function face(key) {
             }
             return new _Promise(function (resolve, reject) {
                 request.put({
-                    uri: faceListUrl + '/' + faceListId,
+                    uri: host + rootPath + faceListPath + '/' + faceListId,
                     headers: { 'Ocp-Apim-Subscription-Key': key },
                     json: true,
                     body: body
@@ -377,7 +377,7 @@ var face = function face(key) {
             }
             return new _Promise(function (resolve, reject) {
                 request.patch({
-                    uri: faceListUrl + '/' + faceListId,
+                    uri: host + rootPath + faceListPath + '/' + faceListId,
                     headers: { 'Ocp-Apim-Subscription-Key': key },
                     json: true,
                     body: body
@@ -397,7 +397,7 @@ var face = function face(key) {
             return new _Promise(function (resolve, reject) {
                 request({
                     method: 'DELETE',
-                    uri: faceListUrl + '/' + faceListId,
+                    uri: host + rootPath + faceListPath + '/' + faceListId,
                     headers: { 'Ocp-Apim-Subscription-Key': key }
                 }, function (error, response) {
                     return _return(error, response, resolve, reject);
@@ -414,7 +414,7 @@ var face = function face(key) {
         get: function get(faceListId) {
             return new _Promise(function (resolve, reject) {
                 request({
-                    uri: faceListUrl + '/' + faceListId,
+                    uri: host + rootPath + faceListPath + '/' + faceListId,
                     headers: { 'Ocp-Apim-Subscription-Key': key }
                 }, function (error, response) {
                     response.body = JSON.parse(response.body);
@@ -437,7 +437,7 @@ var face = function face(key) {
          * @return {Promise}                    - Promise resolving with the resulting JSON
          */
         addFace: function addFace(faceListId, options) {
-            var url = faceListUrl + '/' + faceListId + '/persistedFaces';
+            var url = faceListPath + '/' + faceListId + '/persistedFaces';
             var qs = {};
             if (options) {
                 qs.name = options.name;
@@ -459,7 +459,7 @@ var face = function face(key) {
             return new _Promise(function (resolve, reject) {
                 request({
                     method: 'DELETE',
-                    uri: faceListUrl + '/' + faceListId + '/persistedFaces/' + persistedFaceId,
+                    uri: host + rootPath + faceListPath + '/' + faceListId + '/persistedFaces/' + persistedFaceId,
                     headers: { 'Ocp-Apim-Subscription-Key': key }
                 }, function (error, response) {
                     return _return(error, response, resolve, reject);
@@ -486,7 +486,7 @@ var face = function face(key) {
         create: function create(personGroupId, name, userData) {
             return new _Promise(function (resolve, reject) {
                 request.put({
-                    uri: personGroupUrl + '/' + personGroupId,
+                    uri: host + rootPath + personGroupPath + '/' + personGroupId,
                     headers: { 'Ocp-Apim-Subscription-Key': key },
                     json: true,
                     body: {
@@ -509,7 +509,7 @@ var face = function face(key) {
             return new _Promise(function (resolve, reject) {
                 request({
                     method: 'DELETE',
-                    uri: personGroupUrl + '/' + personGroupId,
+                    uri: host + rootPath + personGroupPath + '/' + personGroupId,
                     headers: { 'Ocp-Apim-Subscription-Key': key }
                 }, function (error, response) {
                     return _return(error, response, resolve, reject);
@@ -526,7 +526,7 @@ var face = function face(key) {
         get: function get(personGroupId) {
             return new _Promise(function (resolve, reject) {
                 request({
-                    uri: personGroupUrl + '/' + personGroupId,
+                    uri: host + rootPath + personGroupPath + '/' + personGroupId,
                     headers: { 'Ocp-Apim-Subscription-Key': key }
                 }, function (error, response) {
                     response.body = JSON.parse(response.body);
@@ -546,7 +546,7 @@ var face = function face(key) {
         trainingStatus: function trainingStatus(personGroupId) {
             return new _Promise(function (resolve, reject) {
                 request({
-                    uri: personGroupUrl + '/' + personGroupId + '/training',
+                    uri: host + rootPath + personGroupPath + '/' + personGroupId + '/training',
                     headers: { 'Ocp-Apim-Subscription-Key': key }
                 }, function (error, response) {
                     response.body = JSON.parse(response.body);
@@ -567,7 +567,7 @@ var face = function face(key) {
         trainingStart: function trainingStart(personGroupId) {
             return new _Promise(function (resolve, reject) {
                 request.post({
-                    uri: personGroupUrl + '/' + personGroupId + '/train',
+                    uri: host + rootPath + personGroupPath + '/' + personGroupId + '/train',
                     headers: { 'Ocp-Apim-Subscription-Key': key }
                 }, function (error, response) {
                     return _return(error, response, resolve, reject);
@@ -586,7 +586,7 @@ var face = function face(key) {
         update: function update(personGroupId, name, userData) {
             return new _Promise(function (resolve, reject) {
                 request.patch({
-                    uri: personGroupUrl + '/' + personGroupId,
+                    uri: host + rootPath + personGroupPath + '/' + personGroupId,
                     headers: { 'Ocp-Apim-Subscription-Key': key },
                     json: true,
                     body: {
@@ -606,7 +606,7 @@ var face = function face(key) {
         list: function list() {
             return new _Promise(function (resolve, reject) {
                 request({
-                    uri: personGroupUrl,
+                    uri: host + rootPath + personGroupPath,
                     headers: { 'Ocp-Apim-Subscription-Key': key }
                 }, function (error, response) {
                     response.body = JSON.parse(response.body);
@@ -642,7 +642,7 @@ var face = function face(key) {
                     qs.targetFace = [options.targetFace.left, options.targetFace.top, options.targetFace.width, options.targetFace.height].join();
                 }
             }
-            var url = personUrl + '/' + personGroupId + '/persons/' + personId + '/persistedFaces';
+            var url = personPath + '/' + personGroupId + '/persons/' + personId + '/persistedFaces';
             return _postImage(url, options, qs);
         },
 
@@ -658,7 +658,7 @@ var face = function face(key) {
             return new _Promise(function (resolve, reject) {
                 request({
                     method: 'DELETE',
-                    uri: personUrl + '/' + personGroupId + '/persons/' + personId + '/persistedFaces/' + persistedFaceId,
+                    uri: host + rootPath + personPath + '/' + personGroupId + '/persons/' + personId + '/persistedFaces/' + persistedFaceId,
                     headers: { 'Ocp-Apim-Subscription-Key': key }
                 }, function (error, response) {
                     return _return(error, response, resolve, reject);
@@ -678,7 +678,7 @@ var face = function face(key) {
         updateFace: function updateFace(personGroupId, personId, persistedFaceId, userData) {
             return new _Promise(function (resolve, reject) {
                 request.patch({
-                    uri: personUrl + '/' + personGroupId + '/persons/' + personId + '/persistedFaces/' + persistedFaceId,
+                    uri: host + rootPath + personPath + '/' + personGroupId + '/persons/' + personId + '/persistedFaces/' + persistedFaceId,
                     headers: { 'Ocp-Apim-Subscription-Key': key },
                     json: true,
                     body: userData ? { userData: userData } : {}
@@ -699,7 +699,7 @@ var face = function face(key) {
         getFace: function getFace(personGroupId, personId, persistedFaceId) {
             return new _Promise(function (resolve, reject) {
                 request({
-                    uri: personUrl + '/' + personGroupId + '/persons/' + personId + '/persistedFaces/' + persistedFaceId,
+                    uri: host + rootPath + personPath + '/' + personGroupId + '/persons/' + personId + '/persistedFaces/' + persistedFaceId,
                     headers: { 'Ocp-Apim-Subscription-Key': key }
                 }, function (error, response) {
                     response.body = JSON.parse(response.body);
@@ -720,7 +720,7 @@ var face = function face(key) {
         create: function create(personGroupId, name, userData) {
             return new _Promise(function (resolve, reject) {
                 request.post({
-                    uri: personUrl + '/' + personGroupId + '/persons',
+                    uri: host + rootPath + personPath + '/' + personGroupId + '/persons',
                     headers: { 'Ocp-Apim-Subscription-Key': key },
                     json: true,
                     body: {
@@ -744,7 +744,7 @@ var face = function face(key) {
             return new _Promise(function (resolve, reject) {
                 request({
                     method: 'DELETE',
-                    uri: personUrl + '/' + personGroupId + '/persons/' + personId,
+                    uri: host + rootPath + personPath + '/' + personGroupId + '/persons/' + personId,
                     headers: { 'Ocp-Apim-Subscription-Key': key }
                 }, function (error, response) {
                     return _return(error, response, resolve, reject);
@@ -762,7 +762,7 @@ var face = function face(key) {
         get: function get(personGroupId, personId) {
             return new _Promise(function (resolve, reject) {
                 request({
-                    uri: personUrl + '/' + personGroupId + '/persons/' + personId,
+                    uri: host + rootPath + personPath + '/' + personGroupId + '/persons/' + personId,
                     headers: { 'Ocp-Apim-Subscription-Key': key }
                 }, function (error, response) {
                     response.body = JSON.parse(response.body);
@@ -782,7 +782,7 @@ var face = function face(key) {
         update: function update(personGroupId, personId, name, userData) {
             return new _Promise(function (resolve, reject) {
                 request.patch({
-                    uri: personUrl + '/' + personGroupId + '/persons/' + personId,
+                    uri: host + rootPath + personPath + '/' + personGroupId + '/persons/' + personId,
                     headers: { 'Ocp-Apim-Subscription-Key': key },
                     json: true,
                     body: {
@@ -804,7 +804,7 @@ var face = function face(key) {
         list: function list(personGroupId) {
             return new _Promise(function (resolve, reject) {
                 request({
-                    uri: personUrl + '/' + personGroupId + '/persons',
+                    uri: host + rootPath + personPath + '/' + personGroupId + '/persons',
                     headers: { 'Ocp-Apim-Subscription-Key': key }
                 }, function (error, response) {
                     response.body = JSON.parse(response.body);

--- a/dist/oxford.js
+++ b/dist/oxford.js
@@ -21,20 +21,23 @@ oxford.makeBuffer = function (dataURL) {
 /**
  * Creates a new Project Oxford Client using a given API key.
  * @class Client
- * @param {string} key - Project Oxford API Key
+ * @param {string} key  - Project Oxford API Key
+ * @param {string} host - Optional host address
  */
-oxford.Client = function (key) {
+oxford.Client = function (key, host) {
     if (!key || key === '') {
         return console.error('Tried to initialize Project Oxford client without API key');
     }
 
+    host = (host || 'https://api.projectoxford.ai').replace('\/$', '');
+
     this._key = key;
-    this.emotion = emotion(key);
-    this.face = face(key);
-    this.text = text(key);
-    this.video = video(key);
-    this.vision = vision(key);
-    this.weblm = weblm(key);
+    this.emotion = emotion(key, host);
+    this.face = face(key, host);
+    this.text = text(key, host);
+    this.video = video(key, host);
+    this.vision = vision(key, host);
+    this.weblm = weblm(key, host);
 };
 
 module.exports = oxford;

--- a/dist/text.js
+++ b/dist/text.js
@@ -1,17 +1,17 @@
 'use strict';
 
 var request = require('request').defaults({
-    baseUrl: 'https://api.projectoxford.ai/text/v1.0/',
-    headers: { 'User-Agent': 'nodejs/0.3.0' } }),
+    headers: { 'User-Agent': 'nodejs/0.4.0' } }),
     _Promise = require('bluebird');
 
-var spellCheckUrl = '/spellcheck';
+var rootPath = '/text/v1.0';
+var spellCheckPath = '/spellcheck';
 
 /**
  * @namespace
  * @memberof Client
  */
-var text = function text(key) {
+var text = function text(key, host) {
     /**
      * @private
      */
@@ -43,7 +43,7 @@ var text = function text(key) {
                 PostContextText: postContextText
             };
             request.post({
-                uri: spellCheckUrl,
+                uri: host + rootPath + spellCheckPath,
                 headers: { 'Ocp-Apim-Subscription-Key': key },
                 form: form,
                 json: true,

--- a/dist/video.js
+++ b/dist/video.js
@@ -1,20 +1,20 @@
 'use strict';
 
 var request = require('request').defaults({
-    headers: { 'User-Agent': 'nodejs/0.3.0' } }),
+    headers: { 'User-Agent': 'nodejs/0.4.0' } }),
     fs = require('fs'),
     _Promise = require('bluebird');
 
-var apiBaseUrl = 'https://api.projectoxford.ai/video/v1.0/';
-var trackFaceUrl = apiBaseUrl + 'trackface';
-var detectMotionrUrl = apiBaseUrl + 'detectmotion';
-var stabilizeUrl = apiBaseUrl + 'stabilize';
+var rootPath = '/video/v1.0';
+var trackFacePath = '/trackface';
+var detectMotionrPath = '/detectmotion';
+var stabilizePath = '/stabilize';
 
 /**
  * @namespace
  * @memberof Client
  */
-var video = function video(key) {
+var video = function video(key, host) {
     /**
      * @private
      */
@@ -127,7 +127,7 @@ var video = function video(key) {
      * @return {Promise}                                - Promise resolving with the resulting JSON
      */
     function trackFace(options) {
-        return _postVideo(trackFaceUrl, options);
+        return _postVideo(host + rootPath + trackFacePath, options);
     }
 
     /**
@@ -141,7 +141,7 @@ var video = function video(key) {
      * @return {Promise}                                - Promise resolving with the resulting JSON
      */
     function detectMotion(options) {
-        return _postVideo(detectMotionrUrl, options);
+        return _postVideo(host + rootPath + detectMotionrPath, options);
     }
 
     /**
@@ -155,7 +155,7 @@ var video = function video(key) {
      * @return {Promise}                                - Promise resolving with the resulting JSON
      */
     function stabilize(options) {
-        return _postVideo(stabilizeUrl, options);
+        return _postVideo(host + rootPath + stabilizePath, options);
     }
 
     /**

--- a/dist/vision.js
+++ b/dist/vision.js
@@ -1,11 +1,11 @@
 'use strict';
 
 var request = require('request').defaults({
-    baseUrl: 'https://api.projectoxford.ai/vision/v1.0/',
-    headers: { 'User-Agent': 'nodejs/0.3.0' } }),
+    headers: { 'User-Agent': 'nodejs/0.4.0' } }),
     fs = require('fs'),
     _Promise = require('bluebird');
 
+var rootPath = '/vision/v1.0';
 var analyzeUrl = '/analyze';
 var thumbnailUrl = '/generateThumbnail';
 var ocrUrl = '/ocr';
@@ -15,7 +15,7 @@ var modelsUrl = '/models';
  * @namespace
  * @memberof Client
  */
-var vision = function vision(key) {
+var vision = function vision(key, host) {
     /**
      * @private
      */
@@ -42,7 +42,7 @@ var vision = function vision(key) {
     function _postLocal(url, image, options) {
         return new _Promise(function (resolve, reject) {
             fs.createReadStream(image).pipe(request.post({
-                uri: url,
+                uri: host + rootPath + url,
                 headers: {
                     'Ocp-Apim-Subscription-Key': key,
                     'Content-Type': 'application/octet-stream'
@@ -66,7 +66,7 @@ var vision = function vision(key) {
     function _postOnline(url, image, options) {
         return new _Promise(function (resolve, reject) {
             request.post({
-                uri: url,
+                uri: host + rootPath + url,
                 headers: { 'Ocp-Apim-Subscription-Key': key },
                 json: true,
                 body: { url: image },
@@ -123,7 +123,7 @@ var vision = function vision(key) {
     function _thumbnailLocal(image, options, pipe) {
         return new _Promise(function (resolve, reject) {
             fs.createReadStream(image).pipe(request.post({
-                uri: thumbnailUrl,
+                uri: host + rootPath + thumbnailUrl,
                 headers: {
                     'Ocp-Apim-Subscription-Key': key,
                     'Content-Type': 'application/octet-stream'
@@ -145,7 +145,7 @@ var vision = function vision(key) {
     function _thumbnailOnline(image, options, pipe) {
         return new _Promise(function (resolve, reject) {
             request.post({
-                uri: thumbnailUrl,
+                uri: host + rootPath + thumbnailUrl,
                 headers: { 'Ocp-Apim-Subscription-Key': key },
                 json: true,
                 body: { url: image },
@@ -223,7 +223,7 @@ var vision = function vision(key) {
         list: function list() {
             return new _Promise(function (resolve, reject) {
                 request({
-                    uri: modelsUrl,
+                    uri: host + rootPath + modelsUrl,
                     headers: { 'Ocp-Apim-Subscription-Key': key }
                 }, function (error, response) {
                     response.body = JSON.parse(response.body);

--- a/dist/weblm.js
+++ b/dist/weblm.js
@@ -1,21 +1,21 @@
 'use strict';
 
 var request = require('request').defaults({
-    baseUrl: 'https://api.projectoxford.ai/text/weblm/v1.0/',
-    headers: { 'User-Agent': 'nodejs/0.3.0' } }),
+    headers: { 'User-Agent': 'nodejs/0.4.0' } }),
     _Promise = require('bluebird');
 
-var workBreakUrl = '/breakIntoWords';
-var listModelsUrl = '/models';
-var generateNextWordsUrl = '/generateNextWords';
-var calculateJointProbUrl = '/calculateJointProbability';
-var calculateCondProbUrl = '/calculateConditionalProbability';
+var rootPath = '/text/weblm/v1.0/';
+var workBreakPath = '/breakIntoWords';
+var listModelsPath = '/models';
+var generateNextWordsPath = '/generateNextWords';
+var calculateJointProbPath = '/calculateJointProbability';
+var calculateCondProbPath = '/calculateConditionalProbability';
 
 /**
  * @namespace
  * @memberof Client
  */
-var weblm = function weblm(key) {
+var weblm = function weblm(key, host) {
     /**
      * @private
      */
@@ -39,7 +39,7 @@ var weblm = function weblm(key) {
     function listModels() {
         return new _Promise(function (resolve, reject) {
             request({
-                uri: listModelsUrl,
+                uri: host + rootPath + listModelsPath,
                 json: true,
                 headers: {
                     'Ocp-Apim-Subscription-Key': key
@@ -73,7 +73,7 @@ var weblm = function weblm(key) {
         }
         return new _Promise(function (resolve, reject) {
             request.post({
-                uri: url,
+                uri: host + rootPath + url,
                 headers: {
                     'Ocp-Apim-Subscription-Key': key,
                     'Content-Type': 'application/json'
@@ -98,7 +98,7 @@ var weblm = function weblm(key) {
      * @return {Promise}                       - Promise resolving with the resulting JSON
      */
     function breakIntoWords(model, text, options) {
-        return _processWords(workBreakUrl, model, { text: text }, undefined, options);
+        return _processWords(workBreakPath, model, { text: text }, undefined, options);
     }
 
     /**
@@ -112,7 +112,7 @@ var weblm = function weblm(key) {
      * @return {Promise}                       - Promise resolving with the resulting JSON
      */
     function generateWords(model, words, options) {
-        return _processWords(generateNextWordsUrl, model, { words: words }, undefined, options);
+        return _processWords(generateNextWordsPath, model, { words: words }, undefined, options);
     }
 
     /**
@@ -124,7 +124,7 @@ var weblm = function weblm(key) {
      * @return {Promise}                       - Promise resolving with the resulting JSON
      */
     function getJointProbabilities(model, phrases, order) {
-        return _processWords(calculateJointProbUrl, model, {}, { queries: phrases }, { order: order });
+        return _processWords(calculateJointProbPath, model, {}, { queries: phrases }, { order: order });
     }
 
     /**
@@ -137,7 +137,7 @@ var weblm = function weblm(key) {
      * @return {Promise}                       - Promise resolving with the resulting JSON
      */
     function getConditionalProbabilities(model, queries, order) {
-        return _processWords(calculateCondProbUrl, model, {}, { queries: queries }, { order: order });
+        return _processWords(calculateCondProbPath, model, {}, { queries: queries }, { order: order });
     }
 
     return {

--- a/src/emotion.js
+++ b/src/emotion.js
@@ -1,16 +1,16 @@
 var request = require('request').defaults({
-        baseUrl: 'https://api.projectoxford.ai/emotion/v1.0/',
-        headers: {'User-Agent': 'nodejs/0.3.0'}}),
+        headers: {'User-Agent': 'nodejs/0.4.0'}}),
     fs = require('fs'),
     _Promise = require('bluebird');
 
-const emotionUrl = '/recognize';
+const rootPath = '/emotion/v1.0';
+const recognizePath = '/recognize';
 
 /**
  * @namespace
  * @memberof Client
  */
-var emotion = function (key) {
+var emotion = function (key, host) {
     /**
      * @private
      */
@@ -35,17 +35,19 @@ var emotion = function (key) {
      */
     function _emotionLocal(image, options) {
         return new _Promise(function (resolve, reject) {
-            fs.createReadStream(image).pipe(request.post({
-                uri: emotionUrl,
+            /*fs.createReadStream(image).pipe(*/
+            request.post({
+                uri: host + rootPath + recognizePath,
                 headers: {
                     'Ocp-Apim-Subscription-Key': key,
                     'Content-Type': 'application/octet-stream'
                 },
-                qs: options
+                qs: options,
+                body: fs.readFileSync(image)
             }, (error, response) => {
                 response.body = JSON.parse(response.body);
                 _return(error, response, resolve, reject);
-            }));
+            })/*)*/;
         });
     }
 
@@ -59,7 +61,7 @@ var emotion = function (key) {
     function _emotionOnline(image, options) {
         return new _Promise(function (resolve, reject) {
             request.post({
-                uri: emotionUrl,
+                uri: host + rootPath + recognizePath,
                 headers: {
                     'Ocp-Apim-Subscription-Key': key,
                     'Content-Type': 'application/json'

--- a/src/face.js
+++ b/src/face.js
@@ -1,23 +1,23 @@
 var request = require('request').defaults({
-        baseUrl: 'https://api.projectoxford.ai/face/v1.0/',
-        headers: {'User-Agent': 'nodejs/0.3.0'}}),
+        headers: {'User-Agent': 'nodejs/0.4.0'}}),
     fs = require('fs'),
     _Promise = require('bluebird');
 
-const detectUrl      = '/detect';
-const similarUrl     = '/findsimilars';
-const groupingUrl    = '/group';
-const identifyUrl    = '/identify';
-const verifyUrl      = '/verify';
-const personGroupUrl = '/persongroups';
-const personUrl      = '/persongroups';
-const faceListUrl    = '/facelists';
+const rootPath        = '/face/v1.0';
+const detectPath      = '/detect';
+const similarPath     = '/findsimilars';
+const groupingPath    = '/group';
+const identifyPath    = '/identify';
+const verifyPath      = '/verify';
+const personGroupPath = '/persongroups';
+const personPath      = '/persongroups';
+const faceListPath    = '/facelists';
 
 /**
  * @namespace
  * @memberof Client
  */
-var face = function (key) {
+var face = function (key, host) {
     /**
      * @private
      */
@@ -45,7 +45,7 @@ var face = function (key) {
     function _postOnline(url, image, options) {
         return new _Promise(function (resolve, reject) {
             request.post({
-                uri: url,
+                uri: host + rootPath + url,
                 headers: {'Ocp-Apim-Subscription-Key': key},
                 json: true,
                 body: {url: image},
@@ -66,7 +66,7 @@ var face = function (key) {
     function _postImageSync(url, image, options) {
         return new _Promise(function (resolve, reject) {
             request.post({
-                uri: url,
+                uri: host + rootPath + url,
                 headers: {
                     'Ocp-Apim-Subscription-Key': key,
                     'Content-Type': 'application/octet-stream'
@@ -95,7 +95,7 @@ var face = function (key) {
     function _postBuffer(url, buffer, options) {
         return new _Promise(function (resolve, reject) {
             request.post({
-                uri: url,
+                uri: host + rootPath + url,
                 headers: {
                     'Ocp-Apim-Subscription-Key': key,
                     'Content-Type': 'application/octet-stream'},
@@ -174,7 +174,7 @@ var face = function (key) {
             returnFaceAttributes: attributes.join()
         };
 
-        return _postImage(detectUrl, options, qs);
+        return _postImage(detectPath, options, qs);
     }
 
     /**
@@ -203,7 +203,7 @@ var face = function (key) {
                 }
             }
             request.post({
-                uri: similarUrl,
+                uri: host + rootPath + similarPath,
                 headers: {'Ocp-Apim-Subscription-Key': key},
                 json: true,
                 body: faces
@@ -232,7 +232,7 @@ var face = function (key) {
             }
 
             request.post({
-                uri: groupingUrl,
+                uri: host + rootPath + groupingPath,
                 headers: {'Ocp-Apim-Subscription-Key': key},
                 json: true,
                 body: faces
@@ -262,7 +262,7 @@ var face = function (key) {
             };
 
             request.post({
-                uri: identifyUrl,
+                uri: host + rootPath + identifyPath,
                 headers: {'Ocp-Apim-Subscription-Key': key},
                 json: true,
                 body: body
@@ -286,7 +286,7 @@ var face = function (key) {
                 };
 
                 request.post({
-                    uri: verifyUrl,
+                    uri: host + rootPath + verifyPath,
                     headers: {'Ocp-Apim-Subscription-Key': key},
                     json: true,
                     body: body
@@ -309,7 +309,7 @@ var face = function (key) {
         list: function () {
             return new _Promise((resolve, reject) => {
                 request({
-                    uri: faceListUrl,
+                    uri: host + rootPath + faceListPath,
                     headers: {'Ocp-Apim-Subscription-Key': key}
                 }, function (error, response) {
                     response.body = JSON.parse(response.body);
@@ -336,7 +336,7 @@ var face = function (key) {
             }
             return new _Promise((resolve, reject) => {
                 request.put({
-                    uri: faceListUrl + '/' + faceListId,
+                    uri: host + rootPath + faceListPath + '/' + faceListId,
                     headers: {'Ocp-Apim-Subscription-Key': key},
                     json: true,
                     body: body
@@ -365,7 +365,7 @@ var face = function (key) {
             }
             return new _Promise((resolve, reject) => {
                 request.patch({
-                    uri: faceListUrl + '/' + faceListId,
+                    uri: host + rootPath + faceListPath + '/' + faceListId,
                     headers: {'Ocp-Apim-Subscription-Key': key},
                     json: true,
                     body: body
@@ -385,7 +385,7 @@ var face = function (key) {
             return new _Promise((resolve, reject) => {
                 request({
                     method: 'DELETE',
-                    uri: faceListUrl + '/' + faceListId,
+                    uri: host + rootPath + faceListPath + '/' + faceListId,
                     headers: {'Ocp-Apim-Subscription-Key': key}
                 }, function (error, response) {
                     return _return(error, response, resolve, reject);
@@ -402,7 +402,7 @@ var face = function (key) {
         get: function (faceListId) {
             return new _Promise((resolve, reject) => {
                 request({
-                    uri: faceListUrl + '/' + faceListId,
+                    uri: host + rootPath + faceListPath + '/' + faceListId,
                     headers: {'Ocp-Apim-Subscription-Key': key}
                 }, function (error, response) {
                     response.body = JSON.parse(response.body);
@@ -425,7 +425,7 @@ var face = function (key) {
          * @return {Promise}                    - Promise resolving with the resulting JSON
          */
         addFace: function (faceListId, options) {
-            let url = faceListUrl + '/' + faceListId + '/persistedFaces';
+            let url = faceListPath + '/' + faceListId + '/persistedFaces';
             let qs = {};
             if (options) {
                 qs.name = options.name;
@@ -447,7 +447,7 @@ var face = function (key) {
             return new _Promise((resolve, reject) => {
                 request({
                     method: 'DELETE',
-                    uri: faceListUrl + '/' + faceListId + '/persistedFaces/' + persistedFaceId,
+                    uri: host + rootPath + faceListPath + '/' + faceListId + '/persistedFaces/' + persistedFaceId,
                     headers: {'Ocp-Apim-Subscription-Key': key}
                 }, function (error, response) {
                     return _return(error, response, resolve, reject);
@@ -474,7 +474,7 @@ var face = function (key) {
         create: function (personGroupId, name, userData) {
             return new _Promise((resolve, reject) => {
                 request.put({
-                    uri: personGroupUrl + '/' + personGroupId,
+                    uri: host + rootPath + personGroupPath + '/' + personGroupId,
                     headers: {'Ocp-Apim-Subscription-Key': key},
                     json: true,
                     body: {
@@ -497,7 +497,7 @@ var face = function (key) {
             return new _Promise((resolve, reject) => {
                 request({
                     method: 'DELETE',
-                    uri: personGroupUrl + '/' + personGroupId,
+                    uri: host + rootPath + personGroupPath + '/' + personGroupId,
                     headers: {'Ocp-Apim-Subscription-Key': key}
                 }, function (error, response) {
                     return _return(error, response, resolve, reject);
@@ -514,7 +514,7 @@ var face = function (key) {
         get: function (personGroupId) {
             return new _Promise((resolve, reject) => {
                 request({
-                    uri: personGroupUrl + '/' + personGroupId,
+                    uri: host + rootPath + personGroupPath + '/' + personGroupId,
                     headers: {'Ocp-Apim-Subscription-Key': key}
                 }, function (error, response) {
                     response.body = JSON.parse(response.body);
@@ -534,7 +534,7 @@ var face = function (key) {
         trainingStatus: function (personGroupId) {
             return new _Promise((resolve, reject) => {
                 request({
-                    uri: personGroupUrl + '/' + personGroupId + '/training',
+                    uri: host + rootPath + personGroupPath + '/' + personGroupId + '/training',
                     headers: {'Ocp-Apim-Subscription-Key': key}
                 }, function (error, response) {
                     response.body = JSON.parse(response.body);
@@ -555,7 +555,7 @@ var face = function (key) {
         trainingStart: function (personGroupId) {
             return new _Promise((resolve, reject) => {
                 request.post({
-                    uri: personGroupUrl + '/' + personGroupId + '/train',
+                    uri: host + rootPath + personGroupPath + '/' + personGroupId + '/train',
                     headers: {'Ocp-Apim-Subscription-Key': key}
                 }, function (error, response) {
                     return _return(error, response, resolve, reject);
@@ -574,7 +574,7 @@ var face = function (key) {
         update: function (personGroupId, name, userData) {
             return new _Promise((resolve, reject) => {
                 request.patch({
-                    uri: personGroupUrl + '/' + personGroupId,
+                    uri: host + rootPath + personGroupPath + '/' + personGroupId,
                     headers: {'Ocp-Apim-Subscription-Key': key},
                     json: true,
                     body: {
@@ -594,7 +594,7 @@ var face = function (key) {
         list: function () {
             return new _Promise((resolve, reject) => {
                 request({
-                    uri: personGroupUrl,
+                    uri: host + rootPath + personGroupPath,
                     headers: {'Ocp-Apim-Subscription-Key': key}
                 }, function (error, response) {
                     response.body = JSON.parse(response.body);
@@ -630,7 +630,7 @@ var face = function (key) {
                     qs.targetFace = [options.targetFace.left, options.targetFace.top, options.targetFace.width, options.targetFace.height].join();
                 }
             }
-            var url = personUrl + '/' + personGroupId + '/persons/' + personId + '/persistedFaces';
+            var url = personPath + '/' + personGroupId + '/persons/' + personId + '/persistedFaces';
             return _postImage(url, options, qs);
         },
 
@@ -646,7 +646,7 @@ var face = function (key) {
             return new _Promise((resolve, reject) => {
                 request({
                     method: 'DELETE',
-                    uri: personUrl + '/' + personGroupId + '/persons/' + personId + '/persistedFaces/' + persistedFaceId,
+                    uri: host + rootPath + personPath + '/' + personGroupId + '/persons/' + personId + '/persistedFaces/' + persistedFaceId,
                     headers: {'Ocp-Apim-Subscription-Key': key}
                 }, (error, response) => _return(error, response, resolve, reject));
             });
@@ -664,7 +664,7 @@ var face = function (key) {
         updateFace: function (personGroupId, personId, persistedFaceId, userData) {
             return new _Promise((resolve, reject) => {
                 request.patch({
-                    uri: personUrl + '/' + personGroupId + '/persons/' + personId + '/persistedFaces/' + persistedFaceId,
+                    uri: host + rootPath + personPath + '/' + personGroupId + '/persons/' + personId + '/persistedFaces/' + persistedFaceId,
                     headers: {'Ocp-Apim-Subscription-Key': key},
                     json: true,
                     body: userData ? {userData: userData} : {}
@@ -683,7 +683,7 @@ var face = function (key) {
         getFace: function (personGroupId, personId, persistedFaceId) {
             return new _Promise((resolve, reject) => {
                 request({
-                    uri: personUrl + '/' + personGroupId + '/persons/' + personId + '/persistedFaces/' + persistedFaceId,
+                    uri: host + rootPath + personPath + '/' + personGroupId + '/persons/' + personId + '/persistedFaces/' + persistedFaceId,
                     headers: {'Ocp-Apim-Subscription-Key': key}
                 }, (error, response) => {
                     response.body = JSON.parse(response.body);
@@ -704,7 +704,7 @@ var face = function (key) {
         create: function (personGroupId, name, userData) {
             return new _Promise((resolve, reject) => {
                 request.post({
-                    uri: personUrl + '/' + personGroupId + '/persons',
+                    uri: host + rootPath + personPath + '/' + personGroupId + '/persons',
                     headers: {'Ocp-Apim-Subscription-Key': key},
                     json: true,
                     body: {
@@ -726,7 +726,7 @@ var face = function (key) {
             return new _Promise((resolve, reject) => {
                 request({
                     method: 'DELETE',
-                    uri: personUrl + '/' + personGroupId + '/persons/' + personId,
+                    uri: host + rootPath + personPath + '/' + personGroupId + '/persons/' + personId,
                     headers: {'Ocp-Apim-Subscription-Key': key}
                 }, (error, response) => _return(error, response, resolve, reject));
             });
@@ -742,7 +742,7 @@ var face = function (key) {
         get: function (personGroupId, personId) {
             return new _Promise((resolve, reject) => {
                 request({
-                    uri: personUrl + '/' + personGroupId + '/persons/' + personId,
+                    uri: host + rootPath + personPath + '/' + personGroupId + '/persons/' + personId,
                     headers: {'Ocp-Apim-Subscription-Key': key}
                 }, (error, response) => {
                     response.body = JSON.parse(response.body);
@@ -762,7 +762,7 @@ var face = function (key) {
         update: function (personGroupId, personId, name, userData) {
             return new _Promise((resolve, reject) => {
                 request.patch({
-                    uri: personUrl + '/' + personGroupId + '/persons/' + personId,
+                    uri: host + rootPath + personPath + '/' + personGroupId + '/persons/' + personId,
                     headers: {'Ocp-Apim-Subscription-Key': key},
                     json: true,
                     body: {
@@ -782,7 +782,7 @@ var face = function (key) {
         list: function (personGroupId) {
             return new _Promise((resolve, reject) => {
                 request({
-                    uri: personUrl + '/' + personGroupId + '/persons',
+                    uri: host + rootPath + personPath + '/' + personGroupId + '/persons',
                     headers: {'Ocp-Apim-Subscription-Key': key}
                 }, (error, response) => {
                     response.body = JSON.parse(response.body);

--- a/src/oxford.js
+++ b/src/oxford.js
@@ -19,20 +19,23 @@ oxford.makeBuffer = function (dataURL) {
 /**
  * Creates a new Project Oxford Client using a given API key.
  * @class Client
- * @param {string} key - Project Oxford API Key
+ * @param {string} key  - Project Oxford API Key
+ * @param {string} host - Optional host address
  */
-oxford.Client = function (key) {
+oxford.Client = function (key, host) {
     if (!key || key === '') {
         return console.error('Tried to initialize Project Oxford client without API key');
     }
 
+    host = (host || 'https://api.projectoxford.ai').replace('\/$', '');
+
     this._key    = key;
-    this.emotion = emotion(key);
-    this.face    = face(key);
-    this.text    = text(key);
-    this.video   = video(key);
-    this.vision  = vision(key);
-    this.weblm   = weblm(key);
+    this.emotion = emotion(key, host);
+    this.face    = face(key, host);
+    this.text    = text(key, host);
+    this.video   = video(key, host);
+    this.vision  = vision(key, host);
+    this.weblm   = weblm(key, host);
 };
 
 module.exports = oxford;

--- a/src/text.js
+++ b/src/text.js
@@ -1,15 +1,15 @@
 var request = require('request').defaults({
-        baseUrl: 'https://api.projectoxford.ai/text/v1.0/',
-        headers: {'User-Agent': 'nodejs/0.3.0'}}),
+        headers: {'User-Agent': 'nodejs/0.4.0'}}),
     _Promise = require('bluebird');
 
-const spellCheckUrl = '/spellcheck';
+const rootPath = '/text/v1.0';
+const spellCheckPath = '/spellcheck';
 
 /**
  * @namespace
  * @memberof Client
  */
-var text = function (key) {
+var text = function (key, host) {
     /**
      * @private
      */
@@ -41,7 +41,7 @@ var text = function (key) {
                 PostContextText: postContextText
             };
             request.post({
-                uri: spellCheckUrl,
+                uri: host + rootPath + spellCheckPath,
                 headers: {'Ocp-Apim-Subscription-Key': key},
                 form: form,
                 json: true,

--- a/src/video.js
+++ b/src/video.js
@@ -1,18 +1,18 @@
 var request = require('request').defaults({
-        headers: {'User-Agent': 'nodejs/0.3.0'}}),
+        headers: {'User-Agent': 'nodejs/0.4.0'}}),
     fs = require('fs'),
     _Promise = require('bluebird');
 
-const apiBaseUrl       = 'https://api.projectoxford.ai/video/v1.0/';
-const trackFaceUrl     = apiBaseUrl + 'trackface';
-const detectMotionrUrl = apiBaseUrl + 'detectmotion';
-const stabilizeUrl     = apiBaseUrl + 'stabilize';
+const rootPath          = '/video/v1.0';
+const trackFacePath     = '/trackface';
+const detectMotionrPath = '/detectmotion';
+const stabilizePath     = '/stabilize';
 
 /**
  * @namespace
  * @memberof Client
  */
-var video = function (key) {
+var video = function (key, host) {
     /**
      * @private
      */
@@ -123,7 +123,7 @@ var video = function (key) {
      * @return {Promise}                                - Promise resolving with the resulting JSON
      */
     function trackFace(options) {
-        return _postVideo(trackFaceUrl, options);
+        return _postVideo(host + rootPath + trackFacePath, options);
     }
 
     /**
@@ -137,7 +137,7 @@ var video = function (key) {
      * @return {Promise}                                - Promise resolving with the resulting JSON
      */
     function detectMotion(options) {
-        return _postVideo(detectMotionrUrl, options);
+        return _postVideo(host + rootPath + detectMotionrPath, options);
     }
 
     /**
@@ -151,7 +151,7 @@ var video = function (key) {
      * @return {Promise}                                - Promise resolving with the resulting JSON
      */
     function stabilize(options) {
-        return _postVideo(stabilizeUrl, options);
+        return _postVideo(host + rootPath + stabilizePath, options);
     }
 
     /**

--- a/src/vision.js
+++ b/src/vision.js
@@ -1,9 +1,9 @@
 var request = require('request').defaults({
-        baseUrl: 'https://api.projectoxford.ai/vision/v1.0/',
-        headers: {'User-Agent': 'nodejs/0.3.0'}}),
+        headers: {'User-Agent': 'nodejs/0.4.0'}}),
     fs = require('fs'),
     _Promise = require('bluebird');
 
+const rootPath     = '/vision/v1.0';
 const analyzeUrl   = '/analyze';
 const thumbnailUrl = '/generateThumbnail';
 const ocrUrl       = '/ocr';
@@ -13,7 +13,7 @@ const modelsUrl    = '/models';
  * @namespace
  * @memberof Client
  */
-var vision = function (key) {
+var vision = function (key, host) {
     /**
      * @private
      */
@@ -40,7 +40,7 @@ var vision = function (key) {
     function _postLocal(url, image, options) {
         return new _Promise(function (resolve, reject) {
             fs.createReadStream(image).pipe(request.post({
-                uri: url,
+                uri: host + rootPath + url,
                 headers: {
                     'Ocp-Apim-Subscription-Key': key,
                     'Content-Type': 'application/octet-stream'
@@ -64,7 +64,7 @@ var vision = function (key) {
     function _postOnline(url, image, options) {
         return new _Promise(function (resolve, reject) {
             request.post({
-                uri: url,
+                uri: host + rootPath + url,
                 headers: {'Ocp-Apim-Subscription-Key': key},
                 json: true,
                 body: {url: image},
@@ -119,7 +119,7 @@ var vision = function (key) {
     function _thumbnailLocal(image, options, pipe) {
         return new _Promise(function (resolve, reject) {
             fs.createReadStream(image).pipe(request.post({
-                uri: thumbnailUrl,
+                uri: host + rootPath + thumbnailUrl,
                 headers: {
                     'Ocp-Apim-Subscription-Key': key,
                     'Content-Type': 'application/octet-stream'
@@ -141,7 +141,7 @@ var vision = function (key) {
     function _thumbnailOnline(image, options, pipe) {
         return new _Promise(function (resolve, reject) {
             request.post({
-                uri: thumbnailUrl,
+                uri: host + rootPath + thumbnailUrl,
                 headers: {'Ocp-Apim-Subscription-Key': key},
                 json: true,
                 body: {url: image},
@@ -218,7 +218,7 @@ var vision = function (key) {
         list: function () {
             return new _Promise((resolve, reject) => {
                 request({
-                    uri: modelsUrl,
+                    uri: host + rootPath + modelsUrl,
                     headers: {'Ocp-Apim-Subscription-Key': key}
                 }, function (error, response) {
                     response.body = JSON.parse(response.body);

--- a/src/weblm.js
+++ b/src/weblm.js
@@ -1,19 +1,19 @@
 var request = require('request').defaults({
-        baseUrl: 'https://api.projectoxford.ai/text/weblm/v1.0/',
-        headers: {'User-Agent': 'nodejs/0.3.0'}}),
+        headers: {'User-Agent': 'nodejs/0.4.0'}}),
     _Promise = require('bluebird');
 
-const workBreakUrl          = '/breakIntoWords';
-const listModelsUrl         = '/models';
-const generateNextWordsUrl  = '/generateNextWords';
-const calculateJointProbUrl = '/calculateJointProbability';
-const calculateCondProbUrl  = '/calculateConditionalProbability';
+const rootPath               = '/text/weblm/v1.0/';
+const workBreakPath          = '/breakIntoWords';
+const listModelsPath         = '/models';
+const generateNextWordsPath  = '/generateNextWords';
+const calculateJointProbPath = '/calculateJointProbability';
+const calculateCondProbPath  = '/calculateConditionalProbability';
 
 /**
  * @namespace
  * @memberof Client
  */
-var weblm = function (key) {
+var weblm = function (key, host) {
     /**
      * @private
      */
@@ -37,7 +37,7 @@ var weblm = function (key) {
     function listModels() {
         return new _Promise(function (resolve, reject) {
             request({
-                uri: listModelsUrl,
+                uri: host + rootPath + listModelsPath,
                 json: true,
                 headers: {
                     'Ocp-Apim-Subscription-Key': key
@@ -69,7 +69,7 @@ var weblm = function (key) {
         }
         return new _Promise(function (resolve, reject) {
             request.post({
-                uri: url,
+                uri: host + rootPath + url,
                 headers: {
                     'Ocp-Apim-Subscription-Key': key,
                     'Content-Type': 'application/json'
@@ -92,7 +92,7 @@ var weblm = function (key) {
      * @return {Promise}                       - Promise resolving with the resulting JSON
      */
     function breakIntoWords(model, text, options) {
-        return _processWords(workBreakUrl, model, {text: text}, undefined, options);
+        return _processWords(workBreakPath, model, {text: text}, undefined, options);
     }
 
     /**
@@ -106,7 +106,7 @@ var weblm = function (key) {
      * @return {Promise}                       - Promise resolving with the resulting JSON
      */
     function generateWords(model, words, options) {
-        return _processWords(generateNextWordsUrl, model, {words: words}, undefined, options);
+        return _processWords(generateNextWordsPath, model, {words: words}, undefined, options);
     }
 
     /**
@@ -118,7 +118,7 @@ var weblm = function (key) {
      * @return {Promise}                       - Promise resolving with the resulting JSON
      */
     function getJointProbabilities(model, phrases, order) {
-        return _processWords(calculateJointProbUrl, model, {}, {queries: phrases}, {order: order});
+        return _processWords(calculateJointProbPath, model, {}, {queries: phrases}, {order: order});
     }
 
     /**
@@ -131,7 +131,7 @@ var weblm = function (key) {
      * @return {Promise}                       - Promise resolving with the resulting JSON
      */
     function getConditionalProbabilities(model, queries, order) {
-        return _processWords(calculateCondProbUrl, model, {}, {queries: queries}, {order: order});
+        return _processWords(calculateCondProbPath, model, {}, {queries: queries}, {order: order});
     }
 
     return {


### PR DESCRIPTION
With the launch of some of the Microsoft Cognitive Services in China, this
nodejs client library has been updated to allow users to specify alternate
host names.  For a Chinese, you might create a client thus:

var face = new oxford.Client(YOUR_CN_FACE_KEY,
                             'https://api.cognitive.azure.cn').face;

face.detect(...)

Note that you will need to get a API key from azure.cn for accessing
Cognitive Services in China.