### PR TITLE
added Buffer image upload option for Emotion API

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ Analyze the emotions of one or more faces in an image.
 | options | <code>Object</code> | Options object |
 | options.url | <code>string</code> | URL to the image file |
 | options.path | <code>string</code> | URL to a local image file |
+| options.data | <code>string</code> | Image as a binary buffer |
 | options.faceRectangles | <code>Array.&lt;Object&gt;</code> | Array of face rectangles.  Face rectangles      are returned in the face.detect and vision.analyzeImage methods. |
 
 <a name="Client.face"></a>

--- a/dist/emotion.js
+++ b/dist/emotion.js
@@ -78,6 +78,31 @@ var emotion = function emotion(key, host) {
     }
 
     /**
+     * (Private) Analyze an image from a Buffer
+     * @private
+     * @param  {Object} image       - Buffer with image
+     * @param  {Object} options     - Options object
+     * @return {Promise}            - Promise resolving with the resulting JSON
+     */
+    function _emotionData(image, options) {
+        return new _Promise(function (resolve, reject) {
+            /*fs.createReadStream(image).pipe(*/
+            request.post({
+                uri: host + rootPath + recognizePath,
+                headers: {
+                    'Ocp-Apim-Subscription-Key': key,
+                    'Content-Type': 'application/octet-stream'
+                },
+                qs: options,
+                body: image
+            }, function (error, response) {
+                response.body = JSON.parse(response.body);
+                _return(error, response, resolve, reject);
+            });
+        });
+    }
+
+    /**
      * Analyze the emotions of one or more faces in an image.
      *
      * @param  {Object}   options                - Options object
@@ -107,6 +132,9 @@ var emotion = function emotion(key, host) {
         }
         if (options.url) {
             return _emotionOnline(options.url, qs);
+        }
+        if (options.data) {
+            return _emotionData(options.data, qs);
         }
     }
 

--- a/src/emotion.js
+++ b/src/emotion.js
@@ -74,6 +74,31 @@ var emotion = function (key, host) {
     }
 
     /**
+     * (Private) Analyze an image from a Buffer
+     * @private
+     * @param  {Object} image       - Buffer with image
+     * @param  {Object} options     - Options object
+     * @return {Promise}            - Promise resolving with the resulting JSON
+     */
+    function _emotionData(image, options) {
+        return new _Promise(function (resolve, reject) {
+            /*fs.createReadStream(image).pipe(*/
+            request.post({
+                uri: host + rootPath + recognizePath,
+                headers: {
+                    'Ocp-Apim-Subscription-Key': key,
+                    'Content-Type': 'application/octet-stream'
+                },
+                qs: options,
+                body: image,
+            }, (error, response) => {
+                response.body = JSON.parse(response.body);
+                _return(error, response, resolve, reject);
+            });
+        });
+    }
+
+    /**
      * Analyze the emotions of one or more faces in an image.
      *
      * @param  {Object}   options                - Options object
@@ -103,6 +128,9 @@ var emotion = function (key, host) {
         }
         if (options.url) {
             return _emotionOnline(options.url, qs);
+        }
+        if (options.data) {
+            return _emotionData(options.data, qs);
         }
     }
 


### PR DESCRIPTION
I've added a function to analyze emotion from a Buffer object - up till now it only supported a local file and URL. This makes it consistant with the Faces API in being able to take a buffer object as a 'data' option.