### PR TITLE
Verify person face

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ client.face.detect({
     analyzesAge: true,
     analyzesGender: true
 }).then(function (response) {
-    console.log('The age is: ' + response[0].attributes.age);
-    console.log('The gender is: ' + response[0].attributes.gender);
+    console.log('The age is: ' + response[0].faceAttributes.age);
+    console.log('The gender is: ' + response[0].faceAttributes.gender);
 });
 ```
 Have a picture of a person and want a computed guess about their emotions?

--- a/README.md
+++ b/README.md
@@ -683,7 +683,7 @@ For the scenarios that are sensitive to accuracy please use with own judgment.
 
 | Param | Type | Description |
 | --- | --- | --- |
-| faces | <code>Array.&lt;string&gt;</code> | Array containing two faceIds to use |
+| faces | <code>Array.&lt;string&gt;</code> &#124; <code>object</code> | An array containing two faceIds to use, or an object with the fields faceId, personId, and personGroupId |
 
 <a name="Client.text"></a>
 

--- a/dist/face.js
+++ b/dist/face.js
@@ -302,28 +302,39 @@ var face = function face(key, host) {
      * Analyzes two faces and determine whether they are from the same person.
      * Verification works well for frontal and near-frontal faces.
      * For the scenarios that are sensitive to accuracy please use with own judgment.
-     * @param  {string[]} faces     - Array containing two faceIds to use
-     * @return {Promise}            - Promise resolving with the resulting JSON
+     * @param  {string[]|object} faces - An array containing two faceIds to use, or an object with the fields faceId, personId, and personGroupId
+     * @return {Promise}               - Promise resolving with the resulting JSON
      */
     function verify(faces) {
         return new _Promise(function (resolve, reject) {
-            if (faces && faces.length > 1) {
-                var body = {
-                    faceId1: faces[0],
-                    faceId2: faces[1]
-                };
-
-                request.post({
-                    uri: host + rootPath + verifyPath,
-                    headers: { 'Ocp-Apim-Subscription-Key': key },
-                    json: true,
-                    body: body
-                }, function (error, response) {
-                    return _return(error, response, resolve, reject);
-                });
+            var body;
+            if (faces instanceof Array) {
+                if (faces.length > 1) {
+                    body = {
+                        faceId1: faces[0],
+                        faceId2: faces[1]
+                    };
+                } else {
+                    return reject('Faces array must contain two face ids');
+                }
+            } else if (faces) {
+                if (faces.faceId && faces.personId && faces.personGroupId) {
+                    body = faces;
+                } else {
+                    return reject('Faces object must have faceId, personId, and personGroupId fields');
+                }
             } else {
-                return reject('Faces array must contain two face ids');
+                return reject('Faces must either be array containing two face ids, or' + 'an object with the fields faceId, personId, and personGroupId');
             }
+
+            request.post({
+                uri: host + rootPath + verifyPath,
+                headers: { 'Ocp-Apim-Subscription-Key': key },
+                json: true,
+                body: body
+            }, function (error, response) {
+                return _return(error, response, resolve, reject);
+            });
         });
     }
 

--- a/dist/face.js
+++ b/dist/face.js
@@ -324,7 +324,7 @@ var face = function face(key, host) {
                     return reject('Faces object must have faceId, personId, and personGroupId fields');
                 }
             } else {
-                return reject('Faces must either be array containing two face ids, or' + 'an object with the fields faceId, personId, and personGroupId');
+                return reject('Faces must either be an array containing two face ids, or' + 'an object with the fields \'faceId\', \'personId\', and \'personGroupId\'');
             }
 
             request.post({

--- a/src/face.js
+++ b/src/face.js
@@ -292,26 +292,38 @@ var face = function (key, host) {
      * Analyzes two faces and determine whether they are from the same person.
      * Verification works well for frontal and near-frontal faces.
      * For the scenarios that are sensitive to accuracy please use with own judgment.
-     * @param  {string[]} faces     - Array containing two faceIds to use
-     * @return {Promise}            - Promise resolving with the resulting JSON
+     * @param  {string[]|object} faces - An array containing two faceIds to use, or an object with the fields faceId, personId, and personGroupId
+     * @return {Promise}               - Promise resolving with the resulting JSON
      */
     function verify(faces) {
         return new _Promise(function (resolve, reject) {
-            if (faces && faces.length > 1) {
-                let body = {
-                    faceId1: faces[0],
-                    faceId2: faces[1]
-                };
-
-                request.post({
-                    uri: host + rootPath + verifyPath,
-                    headers: {'Ocp-Apim-Subscription-Key': key},
-                    json: true,
-                    body: body
-                }, (error, response) => _return(error, response, resolve, reject));
+            var body;
+            if (faces instanceof Array) {
+                if (faces.length > 1) {
+                    body = {
+                        faceId1: faces[0],
+                        faceId2: faces[1]
+                    };
+                } else {
+                    return reject('Faces array must contain two face ids');
+                }
+            } else if (faces) {
+                if (faces.faceId && faces.personId && faces.personGroupId) {
+                    body = faces;
+                } else {
+                    return reject('Faces object must have faceId, personId, and personGroupId fields');
+                }
             } else {
-                return reject('Faces array must contain two face ids');
+                return reject('Faces must either be array containing two face ids, or' +
+                    'an object with the fields faceId, personId, and personGroupId');
             }
+
+            request.post({
+                uri: host + rootPath + verifyPath,
+                headers: {'Ocp-Apim-Subscription-Key': key},
+                json: true,
+                body: body
+            }, (error, response) => _return(error, response, resolve, reject));
         });
     }
 

--- a/src/face.js
+++ b/src/face.js
@@ -314,8 +314,8 @@ var face = function (key, host) {
                     return reject('Faces object must have faceId, personId, and personGroupId fields');
                 }
             } else {
-                return reject('Faces must either be array containing two face ids, or' +
-                    'an object with the fields faceId, personId, and personGroupId');
+                return reject('Faces must either be an array containing two face ids, or' +
+                    'an object with the fields \'faceId\', \'personId\', and \'personGroupId\'');
             }
 
             request.post({

--- a/test/test_face.js
+++ b/test/test_face.js
@@ -7,7 +7,8 @@ var assert   = require('assert'),
     client   = new oxford.Client(process.env.OXFORD_KEY);
 
 // Store variables, no point in calling the api too often
-var billFaces = [],
+var billFaceId,
+    billFaces = [],
     billPersistedFaces = [],
     personGroupId = uuid.v4(),
     personGroupId2 = uuid.v4(),
@@ -37,7 +38,7 @@ describe('Project Oxford Face API Test', function () {
                 analyzesGlasses: true,
                 analyzesEmotion: true
             }).then(function (response) {
-                assert.ok(response[0].faceId);
+                assert.ok(billFaceId = response[0].faceId);
                 assert.ok(response[0].faceRectangle);
                 assert.ok(response[0].faceLandmarks);
                 assert.ok(response[0].faceAttributes.gender);
@@ -758,6 +759,23 @@ describe('Project Oxford Face API Test', function () {
             .then(function (response) {
                 assert.equal(response.persistedFaceId, billPersonPersistedFaceId);
                 assert.equal(response.userData, 'test-data-face');
+                done();
+            })
+            .catch(function (error) {
+                assert.ok(false, JSON.stringify(error));
+                done();
+            });
+        });
+
+        it('verify a face of a Person in a PersonGroup', function (done) {
+            client.face.verify({
+                faceId: billFaceId,
+	            personId: billPersonId,
+                personGroupId: personGroupId2
+            })
+            .then(function (response) {
+                assert.ok(true, response.isIdentical);
+                assert.ok(response.confidence > 0.5);
                 done();
             })
             .catch(function (error) {


### PR DESCRIPTION
Face.verify now supports two ways to operate, to match the public API:

1) Test if two face IDs from `detect` call match.
2) Test is a face ID from `detect` matches a `person` in a `personGroup`.